### PR TITLE
ci: add deploy workflow for apps with deploy scripts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,34 @@
+name: Deploy
+
+on:
+  push:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        app:
+          - ethang-hono
+          - sterett-hono
+          - auth
+          - url-shortener
+          - sanity-calendar-sync
+          - ethang-admin
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      SANITY_AUTH_TOKEN: ${{ secrets.SANITY_AUTH_TOKEN }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1  # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter ${{ matrix.app }} deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,9 +20,6 @@ jobs:
           - url-shortener
           - sanity-calendar-sync
           - ethang-admin
-    env:
-      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-      SANITY_AUTH_TOKEN: ${{ secrets.SANITY_AUTH_TOKEN }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1  # v4
@@ -31,4 +28,7 @@ jobs:
           node-version: '24'
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
-      - run: pnpm --filter ${{ matrix.app }} deploy
+      - run: pnpm --filter '${{ matrix.app }}' deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          SANITY_AUTH_TOKEN: ${{ secrets.SANITY_AUTH_TOKEN }}

--- a/docs/superpowers/plans/2026-03-29-deploy-workflow.md
+++ b/docs/superpowers/plans/2026-03-29-deploy-workflow.md
@@ -1,0 +1,103 @@
+# Deploy Workflow Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Create `.github/workflows/deploy.yml` that builds and deploys all apps with a `deploy` script whenever a commit lands on `master`.
+
+**Architecture:** A single workflow file with one matrix job (`fail-fast: false`) that runs `pnpm --filter <app> deploy` for each of the 6 deployable apps in parallel. Secrets are exposed at the job level so every matrix entry receives them.
+
+**Tech Stack:** GitHub Actions, pnpm, wrangler (Cloudflare Workers), Sanity CLI
+
+---
+
+### Task 1: Create the deploy workflow file
+
+**Files:**
+- Create: `.github/workflows/deploy.yml`
+
+> Note: This is a workflow file, not application code — there is no unit test to write. Verification is done by validating the YAML syntax locally before committing.
+
+- [ ] **Step 1: Verify `actionlint` or `yamllint` is available (or skip to step 2)**
+
+Run:
+```bash
+yamllint --version
+```
+If not installed, skip linting — GitHub's own parser will catch syntax errors on push.
+
+- [ ] **Step 2: Create `.github/workflows/deploy.yml`**
+
+```yaml
+name: Deploy
+
+on:
+  push:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        app:
+          - ethang-hono
+          - sterett-hono
+          - auth
+          - url-shortener
+          - sanity-calendar-sync
+          - ethang-admin
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      SANITY_AUTH_TOKEN: ${{ secrets.SANITY_AUTH_TOKEN }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1  # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter ${{ matrix.app }} deploy
+```
+
+- [ ] **Step 3: Verify YAML is well-formed**
+
+Run:
+```bash
+cat .github/workflows/deploy.yml
+```
+Expected: file prints without error, indentation looks correct, no tabs (GitHub Actions requires spaces).
+
+- [ ] **Step 4: Confirm the 6 apps in the matrix each have a `deploy` script**
+
+Run:
+```bash
+grep -r '"deploy"' apps/*/package.json
+```
+Expected output (6 matches):
+```
+apps/auth/package.json:    "deploy": ...
+apps/ethang-admin/package.json:    "deploy": ...
+apps/ethang-hono/package.json:    "deploy": ...
+apps/sanity-calendar-sync/package.json:    "deploy": ...
+apps/sterett-hono/package.json:    "deploy": ...
+apps/url-shortener/package.json:    "deploy": ...
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/deploy.yml
+git commit -m "ci: add deploy workflow for apps with deploy scripts"
+```
+
+- [ ] **Step 6: Verify the workflow appears in GitHub Actions**
+
+Push to master (or open a PR targeting master, merge it), then visit:
+`https://github.com/<owner>/ethang-monorepo/actions`
+
+Expected: a "Deploy" workflow run appears, with 6 parallel matrix jobs. Confirm each job reaches the deploy step. Any `wrangler: error` or `sanity: error` at this point indicates a missing or incorrect secret — check **Settings → Secrets and variables → Actions** and confirm `CLOUDFLARE_API_TOKEN` and `SANITY_AUTH_TOKEN` are set.

--- a/docs/superpowers/plans/2026-03-29-vitest-sonarcloud-coverage.md
+++ b/docs/superpowers/plans/2026-03-29-vitest-sonarcloud-coverage.md
@@ -1,0 +1,482 @@
+# Vitest → SonarCloud Coverage Reporting Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire Vitest unit test coverage from all 8 packages/apps into SonarCloud using LCOV reports and a dedicated CI job.
+
+**Architecture:** Add `lcov` to vitest reporter arrays in all packages, create vitest configs for packages that lack them, add a root-level `sonar-project.properties`, and extend the GitHub Actions CI with a `sonar` job that runs tests then uploads results via `sonarqube-scan-action@v7.0.0`.
+
+**Tech Stack:** Vitest, `@vitest/coverage-v8`, SonarCloud, `SonarSource/sonarqube-scan-action@v7.0.0`, GitHub Actions
+
+---
+
+### Task 1: Create worktree
+
+**Files:**
+- No file changes — sets up isolated working environment
+
+- [ ] **Step 1: Create a new branch and worktree**
+
+Run from the monorepo root:
+```bash
+git worktree add ../ethang-monorepo-sonar feature/vitest-sonarcloud-coverage
+cd ../ethang-monorepo-sonar
+```
+
+- [ ] **Step 2: Verify worktree is on the correct branch**
+
+```bash
+git branch --show-current
+```
+Expected output: `feature/vitest-sonarcloud-coverage`
+
+---
+
+### Task 2: Add `lcov` reporter to existing vitest configs
+
+**Files:**
+- Modify: `apps/ethang-hono/vitest.config.ts`
+- Modify: `apps/sterett-hono/vitest.config.ts`
+- Modify: `apps/url-shortener/vitest.config.ts`
+- Modify: `packages/eslint-config/vitest.config.ts`
+
+- [ ] **Step 1: Verify no lcov.info files exist yet**
+
+```bash
+find . -name "lcov.info" -not -path "*/node_modules/*"
+```
+Expected: no output.
+
+- [ ] **Step 2: Update apps/ethang-hono/vitest.config.ts**
+
+Change the `reporter` array from:
+```ts
+reporter: ["text", "json", "html"],
+```
+to:
+```ts
+reporter: ["text", "json", "html", "lcov"],
+```
+
+- [ ] **Step 3: Update apps/sterett-hono/vitest.config.ts**
+
+Change the `reporter` array from:
+```ts
+reporter: ["text", "json", "html"],
+```
+to:
+```ts
+reporter: ["text", "json", "html", "lcov"],
+```
+
+- [ ] **Step 4: Update apps/url-shortener/vitest.config.ts**
+
+Change the `reporter` array from:
+```ts
+reporter: ["text", "json", "html"],
+```
+to:
+```ts
+reporter: ["text", "json", "html", "lcov"],
+```
+
+- [ ] **Step 5: Update packages/eslint-config/vitest.config.ts**
+
+Change the `reporter` array from:
+```ts
+reporter: ["text", "json", "html"],
+```
+to:
+```ts
+reporter: ["text", "json", "html", "lcov"],
+```
+
+- [ ] **Step 6: Run ethang-hono tests to confirm lcov.info is generated**
+
+```bash
+cd apps/ethang-hono && pnpm test && cd ../..
+```
+Expected: tests pass, then:
+```bash
+ls apps/ethang-hono/coverage/lcov.info
+```
+Expected: file exists.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/ethang-hono/vitest.config.ts apps/sterett-hono/vitest.config.ts apps/url-shortener/vitest.config.ts packages/eslint-config/vitest.config.ts
+git commit -m "chore: add lcov reporter to existing vitest coverage configs"
+```
+
+---
+
+### Task 3: Add coverage config to packages/leetcode, packages/markdown-generator, packages/store
+
+These three packages have no vitest config and no `@vitest/coverage-v8` dependency.
+
+**Files:**
+- Modify: `packages/leetcode/package.json`
+- Create: `packages/leetcode/vitest.config.ts`
+- Modify: `packages/markdown-generator/package.json`
+- Create: `packages/markdown-generator/vitest.config.ts`
+- Modify: `packages/store/package.json`
+- Create: `packages/store/vitest.config.ts`
+
+- [ ] **Step 1: Add @vitest/coverage-v8 devDependency to leetcode**
+
+In `packages/leetcode/package.json`, add to `devDependencies`:
+```json
+"@vitest/coverage-v8": "^4.1.2"
+```
+
+- [ ] **Step 2: Update test script in packages/leetcode/package.json**
+
+Change:
+```json
+"test": "vitest run"
+```
+to:
+```json
+"test": "vitest run --coverage"
+```
+
+- [ ] **Step 3: Create packages/leetcode/vitest.config.ts**
+
+```ts
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      include: ["src/**/*.ts"],
+      provider: "v8",
+      reporter: ["text", "json", "html", "lcov"],
+      thresholds: {
+        autoUpdate: true,
+        branches: 0,
+        functions: 0,
+        lines: 0,
+        statements: 0,
+      },
+    },
+  },
+});
+```
+
+- [ ] **Step 4: Add @vitest/coverage-v8 devDependency to markdown-generator**
+
+In `packages/markdown-generator/package.json`, add to `devDependencies`:
+```json
+"@vitest/coverage-v8": "^4.1.2"
+```
+
+- [ ] **Step 5: Update test script in packages/markdown-generator/package.json**
+
+Change:
+```json
+"test": "vitest run"
+```
+to:
+```json
+"test": "vitest run --coverage"
+```
+
+- [ ] **Step 6: Create packages/markdown-generator/vitest.config.ts**
+
+```ts
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      include: ["src/**/*.ts"],
+      provider: "v8",
+      reporter: ["text", "json", "html", "lcov"],
+      thresholds: {
+        autoUpdate: true,
+        branches: 0,
+        functions: 0,
+        lines: 0,
+        statements: 0,
+      },
+    },
+  },
+});
+```
+
+- [ ] **Step 7: Add @vitest/coverage-v8 devDependency to store**
+
+In `packages/store/package.json`, add to `devDependencies`:
+```json
+"@vitest/coverage-v8": "^4.1.2"
+```
+
+- [ ] **Step 8: Update test script in packages/store/package.json**
+
+Change:
+```json
+"test": "vitest run"
+```
+to:
+```json
+"test": "vitest run --coverage"
+```
+
+- [ ] **Step 9: Create packages/store/vitest.config.ts**
+
+```ts
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      include: ["src/**/*.ts"],
+      provider: "v8",
+      reporter: ["text", "json", "html", "lcov"],
+      thresholds: {
+        autoUpdate: true,
+        branches: 0,
+        functions: 0,
+        lines: 0,
+        statements: 0,
+      },
+    },
+  },
+});
+```
+
+- [ ] **Step 10: Install new dependencies**
+
+```bash
+pnpm install
+```
+Expected: lockfile updated, no errors.
+
+- [ ] **Step 11: Run tests for all three packages to verify lcov.info is generated**
+
+```bash
+cd packages/leetcode && pnpm test && cd ../..
+cd packages/markdown-generator && pnpm test && cd ../..
+cd packages/store && pnpm test && cd ../..
+```
+Expected: all pass, then:
+```bash
+ls packages/leetcode/coverage/lcov.info packages/markdown-generator/coverage/lcov.info packages/store/coverage/lcov.info
+```
+Expected: all three files exist.
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add packages/leetcode/package.json packages/leetcode/vitest.config.ts
+git add packages/markdown-generator/package.json packages/markdown-generator/vitest.config.ts
+git add packages/store/package.json packages/store/vitest.config.ts
+git add pnpm-lock.yaml
+git commit -m "chore: add vitest coverage config to leetcode, markdown-generator, store"
+```
+
+---
+
+### Task 4: Add coverage config to packages/toolbelt
+
+`toolbelt` already has `@vitest/coverage-v8` but no `vitest.config.ts`. Its test script uses `--coverage.enabled=true` (a CLI flag) rather than a config file.
+
+**Files:**
+- Create: `packages/toolbelt/vitest.config.ts`
+- Modify: `packages/toolbelt/package.json`
+
+- [ ] **Step 1: Create packages/toolbelt/vitest.config.ts**
+
+```ts
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      include: ["src/**/*.ts"],
+      provider: "v8",
+      reporter: ["text", "json", "html", "lcov"],
+      thresholds: {
+        autoUpdate: true,
+        branches: 0,
+        functions: 0,
+        lines: 0,
+        statements: 0,
+      },
+    },
+  },
+});
+```
+
+- [ ] **Step 2: Update test script in packages/toolbelt/package.json**
+
+Change:
+```json
+"test": "vitest run --coverage.enabled=true"
+```
+to:
+```json
+"test": "vitest run --coverage"
+```
+
+- [ ] **Step 3: Run tests to verify lcov.info is generated**
+
+```bash
+cd packages/toolbelt && pnpm test && cd ../..
+```
+Expected: tests pass, then:
+```bash
+ls packages/toolbelt/coverage/lcov.info
+```
+Expected: file exists.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/toolbelt/vitest.config.ts packages/toolbelt/package.json
+git commit -m "chore: add vitest coverage config to toolbelt"
+```
+
+---
+
+### Task 5: Create sonar-project.properties
+
+**Files:**
+- Create: `sonar-project.properties`
+
+- [ ] **Step 1: Create sonar-project.properties at the monorepo root**
+
+```properties
+sonar.projectKey=eglove_ethang-monorepo
+sonar.organization=eglove
+
+sonar.sources=\
+  apps/ethang-hono/src,\
+  apps/sterett-hono/src,\
+  apps/url-shortener/src,\
+  packages/eslint-config/src,\
+  packages/leetcode/src,\
+  packages/markdown-generator/src,\
+  packages/store/src,\
+  packages/toolbelt/src
+
+sonar.exclusions=\
+  **/node_modules/**,\
+  **/*.test.ts,\
+  **/*.test.tsx,\
+  **/*.spec.ts,\
+  **/*.spec.tsx,\
+  **/e2e/**,\
+  **/vitest.config.ts,\
+  **/coverage/**
+
+sonar.javascript.lcov.reportPaths=\
+  apps/ethang-hono/coverage/lcov.info,\
+  apps/sterett-hono/coverage/lcov.info,\
+  apps/url-shortener/coverage/lcov.info,\
+  packages/eslint-config/coverage/lcov.info,\
+  packages/leetcode/coverage/lcov.info,\
+  packages/markdown-generator/coverage/lcov.info,\
+  packages/store/coverage/lcov.info,\
+  packages/toolbelt/coverage/lcov.info
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add sonar-project.properties
+git commit -m "chore: add sonar-project.properties for SonarCloud monorepo coverage"
+```
+
+---
+
+### Task 6: Add sonar job to CI
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+
+- [ ] **Step 1: Add the sonar job to .github/workflows/ci.yml**
+
+Add the following job at the end of the `jobs:` section. Use the same pinned SHA format as the rest of the file:
+
+```yaml
+  sonar:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          fetch-depth: 0
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1  # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm test
+      - uses: SonarSource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9  # v7.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+```
+
+**Note on `fetch-depth: 0`:** SonarCloud requires the full git history to calculate blame information and identify new vs. existing code. Without this, SonarCloud cannot accurately report on new code in pull requests.
+
+**Note on re-running tests:** GitHub Actions jobs do not share filesystem state. The coverage reports from the `test` job are not available in the `sonar` job. Re-running `pnpm test` here regenerates all `lcov.info` files in the same job before the scan runs.
+
+- [ ] **Step 2: Verify CI file is valid YAML**
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))" && echo "YAML valid"
+```
+Expected: `YAML valid`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "ci: add sonar job for SonarCloud coverage reporting"
+```
+
+---
+
+### Task 7: Final verification
+
+- [ ] **Step 1: Run all tests from the monorepo root**
+
+```bash
+pnpm test
+```
+Expected: all packages pass with exit code 0.
+
+- [ ] **Step 2: Verify all 8 lcov.info files exist**
+
+```bash
+ls \
+  apps/ethang-hono/coverage/lcov.info \
+  apps/sterett-hono/coverage/lcov.info \
+  apps/url-shortener/coverage/lcov.info \
+  packages/eslint-config/coverage/lcov.info \
+  packages/leetcode/coverage/lcov.info \
+  packages/markdown-generator/coverage/lcov.info \
+  packages/store/coverage/lcov.info \
+  packages/toolbelt/coverage/lcov.info
+```
+Expected: all 8 files listed with no errors.
+
+- [ ] **Step 3: Push the branch**
+
+```bash
+git push -u origin feature/vitest-sonarcloud-coverage
+```
+
+- [ ] **Step 4: Open a pull request**
+
+```bash
+gh pr create \
+  --title "chore: wire vitest coverage to SonarCloud" \
+  --body "Adds lcov coverage reporting to all 8 packages/apps and configures SonarCloud to pick them up via a new CI job. Requires SONAR_TOKEN secret to be set in GitHub Actions secrets."
+```
+
+**Prerequisite reminder:** Before the CI sonar job can succeed, a `SONAR_TOKEN` secret must be added to the repository's GitHub Actions secrets. Obtain it from SonarCloud → My Account → Security → Generate Token.

--- a/docs/superpowers/specs/2026-03-29-deploy-workflow-design.md
+++ b/docs/superpowers/specs/2026-03-29-deploy-workflow-design.md
@@ -1,0 +1,59 @@
+# Deploy Workflow Design
+
+**Date:** 2026-03-29
+**Topic:** GitHub CI deploy workflow on merge to master
+
+## Overview
+
+Add a new `.github/workflows/deploy.yml` that automatically builds and deploys all apps that have a `deploy` script whenever a branch merges into `master`.
+
+## Trigger
+
+```yaml
+on:
+  push:
+    branches: [master]
+```
+
+PR builds are already handled by `ci.yml`. This workflow only runs after a merge.
+
+## Job Structure
+
+A single `deploy` job uses a matrix strategy with `fail-fast: false` so each app deploys independently — a failure in one does not cancel the others.
+
+**Matrix apps (all currently have a `deploy` script):**
+- `ethang-hono`
+- `sterett-hono`
+- `auth`
+- `url-shortener`
+- `sanity-calendar-sync`
+- `ethang-admin`
+
+## Steps (per matrix entry)
+
+1. `actions/checkout` — pinned SHA matching `ci.yml`
+2. `pnpm/action-setup` — pinned SHA matching `ci.yml`
+3. `actions/setup-node` (Node 24, pnpm cache) — pinned SHA matching `ci.yml`
+4. `pnpm install --frozen-lockfile`
+5. `pnpm --filter ${{ matrix.app }} deploy`
+
+`bun` is a root devDependency so it is available on PATH after install. No additional setup step is needed for apps whose deploy scripts invoke `bun` directly (`ethang-hono`, `sterett-hono`).
+
+## Secrets
+
+Two repository secrets must be added under **GitHub → Settings → Secrets and variables → Actions**:
+
+| Secret | Used by |
+|--------|---------|
+| `CLOUDFLARE_API_TOKEN` | All wrangler-based apps (5 apps) |
+| `SANITY_AUTH_TOKEN` | `ethang-admin` (`sanity deploy`) |
+
+Both are exposed at the job level via `env:` so all matrix entries receive them.
+
+## Adding New Deployable Apps
+
+When a new app gains a `deploy` script, add its package name to the matrix list. No other changes required.
+
+## File to Create
+
+- `.github/workflows/deploy.yml`

--- a/docs/superpowers/specs/2026-03-29-vitest-sonarcloud-coverage-design.md
+++ b/docs/superpowers/specs/2026-03-29-vitest-sonarcloud-coverage-design.md
@@ -1,0 +1,140 @@
+# Design: Vitest Coverage Reporting to SonarCloud
+
+**Date:** 2026-03-29
+**Branch:** feature/vitest-sonarcloud-coverage (worktree)
+
+## Overview
+
+Wire Vitest unit test coverage from all packages/apps that have a `test` script into SonarCloud, using a centralized `sonar-project.properties` file and a dedicated CI job.
+
+## Scope
+
+8 packages/apps in the monorepo have a `test` script:
+
+| Package | Has vitest config? | Has coverage? |
+|---|---|---|
+| apps/ethang-hono | yes | yes (thresholds set) |
+| apps/sterett-hono | yes | yes (thresholds set) |
+| apps/url-shortener | yes | yes (no thresholds) |
+| packages/eslint-config | yes | yes (thresholds set) |
+| packages/leetcode | no | no |
+| packages/markdown-generator | no | no |
+| packages/store | no | no |
+| packages/toolbelt | no | no |
+
+## Section 1: Vitest Coverage Changes
+
+### Packages with existing coverage config
+
+Add `"lcov"` to the `reporter` array in the vitest config for:
+- `apps/ethang-hono/vitest.config.ts`
+- `apps/sterett-hono/vitest.config.ts`
+- `apps/url-shortener/vitest.config.ts`
+- `packages/eslint-config/vitest.config.ts`
+
+All other settings (thresholds, includes, excludes) remain unchanged.
+
+### Packages without vitest config
+
+Create `vitest.config.ts` for each of: `packages/leetcode`, `packages/markdown-generator`, `packages/store`, `packages/toolbelt`.
+
+Each config follows this template:
+
+```ts
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      include: ["src/**/*.ts"],
+      provider: "v8",
+      reporter: ["text", "json", "html", "lcov"],
+      thresholds: {
+        autoUpdate: true,
+        branches: 0,
+        functions: 0,
+        lines: 0,
+        statements: 0,
+      },
+    },
+  },
+});
+```
+
+Update each package's `test` script to include `--coverage`:
+
+```json
+"test": "vitest run --coverage"
+```
+
+## Section 2: sonar-project.properties
+
+Create a `sonar-project.properties` file at the monorepo root:
+
+```properties
+sonar.projectKey=eglove_ethang-monorepo
+sonar.organization=eglove
+
+sonar.sources=\
+  apps/ethang-hono/src,\
+  apps/sterett-hono/src,\
+  apps/url-shortener/src,\
+  packages/eslint-config/src,\
+  packages/leetcode/src,\
+  packages/markdown-generator/src,\
+  packages/store/src,\
+  packages/toolbelt/src
+
+sonar.exclusions=\
+  **/node_modules/**,\
+  **/*.test.ts,\
+  **/*.test.tsx,\
+  **/*.spec.ts,\
+  **/e2e/**,\
+  **/vitest.config.ts,\
+  **/coverage/**
+
+sonar.javascript.lcov.reportPaths=\
+  apps/ethang-hono/coverage/lcov.info,\
+  apps/sterett-hono/coverage/lcov.info,\
+  apps/url-shortener/coverage/lcov.info,\
+  packages/eslint-config/coverage/lcov.info,\
+  packages/leetcode/coverage/lcov.info,\
+  packages/markdown-generator/coverage/lcov.info,\
+  packages/store/coverage/lcov.info,\
+  packages/toolbelt/coverage/lcov.info
+```
+
+## Section 3: CI Workflow
+
+Add a `sonar` job to `.github/workflows/ci.yml` after the existing `test` job:
+
+```yaml
+sonar:
+  needs: test
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@<pinned-sha>  # v4, fetch-depth: 0
+      with:
+        fetch-depth: 0
+    - uses: pnpm/action-setup@<pinned-sha>  # v4
+    - uses: actions/setup-node@<pinned-sha>  # v4
+      with:
+        node-version: '24'
+        cache: 'pnpm'
+    - run: pnpm install --frozen-lockfile
+    - run: pnpm test
+    - uses: SonarSource/sonarcloud-github-action@v3
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+```
+
+**Note:** `fetch-depth: 0` is required by SonarCloud for accurate blame analysis and new code detection. The `SONAR_TOKEN` secret must be added to the repository's GitHub Actions secrets manually before this workflow will succeed.
+
+Action SHA pins must follow the existing repo convention (pinned to commit SHAs, not floating tags).
+
+## Prerequisites (Manual Steps)
+
+- Add `SONAR_TOKEN` secret to the GitHub repository Actions secrets.
+  - Obtain from SonarCloud → My Account → Security → Generate Token.


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/deploy.yml` triggered on push to `master`
- Matrix job with `fail-fast: false` deploys 6 apps in parallel: `ethang-hono`, `sterett-hono`, `auth`, `url-shortener`, `sanity-calendar-sync`, `ethang-admin`
- Secrets (`CLOUDFLARE_API_TOKEN`, `SANITY_AUTH_TOKEN`) scoped to the deploy step only

## Test Plan
- [ ] Add `CLOUDFLARE_API_TOKEN` and `SANITY_AUTH_TOKEN` to GitHub repository secrets
- [ ] Merge this PR and verify 6 parallel deploy jobs appear in the Actions tab
- [ ] Confirm each app reaches the deploy step without credential errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)