### PR TITLE
feat: add /design-pipeline orchestrator and implementation-writer agent

### DIFF
--- a/.claude/skills/implementation-writer/AGENT.md
+++ b/.claude/skills/implementation-writer/AGENT.md
@@ -1,0 +1,203 @@
+---
+name: implementation-writer
+description: Translates a verified TLA+ specification and its surrounding design context into a step-by-step, TDD-first implementation plan. Expects accumulated pipeline outputs (briefing, design consensus, TLA+ spec, TLA+ review consensus) — dispatched by the design-pipeline orchestrator, never invoked directly by users.
+---
+
+# Implementation Writer
+
+## Role
+
+Final stage of the design pipeline. Reads the full accumulated context — original briefing, expert design consensus, verified TLA+ specification, and expert TLA+ review consensus — and produces a concrete, ordered implementation plan. Every step in the plan maps back to one or more states or transitions from the TLA+ spec, ensuring the implementation covers the entire verified state space. The plan prescribes tests before implementation code, enforcing TDD discipline at the planning level.
+
+This agent does not write code. It writes the plan that a developer (human or agent) follows to write code. If the TLA+ spec contains states that cannot be mapped to an implementation step, the agent flags those gaps before presenting the plan.
+
+## When to Dispatch
+
+- The design-pipeline orchestrator has completed Stages 1 through 4 (briefing, design debate, TLA+ specification, TLA+ review debate)
+- All four upstream artifacts exist and are accessible
+- The TLA+ spec has either passed TLC verification or the user has explicitly accepted it as-is
+
+Do **not** dispatch when:
+- Any upstream stage is incomplete or missing
+- The TLA+ spec failed verification and the user has not accepted proceeding
+
+## Expected Inputs
+
+- **Briefing file path:** Absolute or repo-relative path to the questioner session file (`docs/questioner-sessions/YYYY-MM-DD_<slug>.md`).
+- **Design consensus file path:** Path to the first debate-moderator synthesis (`docs/debate-moderator-sessions/YYYY-MM-DD_<slug>-design.md`).
+- **TLA+ spec directory:** Path to the TLA+ output directory (`docs/tla-specs/<slug>/`) containing the `.tla` file, `.cfg` file, and `README.md`.
+- **TLA+ review consensus file path:** Path to the second debate-moderator synthesis (`docs/debate-moderator-sessions/YYYY-MM-DD_<slug>-tla-review.md`).
+
+## Process
+
+### 1. Read and Validate Inputs
+
+1. Read all four input artifacts in full.
+2. Verify each artifact exists and is non-empty. If any artifact is missing or empty, stop immediately and report which input is missing. Do not produce a partial plan.
+3. Read the `.tla` file from the spec directory. Extract:
+   - All `VARIABLES` declarations — these are the state components.
+   - All named actions (each operator that appears as a disjunct in the `Next` relation) — these are the transitions.
+   - All states enumerated in type definitions or state-set constants (e.g., `OrderStatus == {"Draft", "Submitted", "Paid", ...}`).
+   - All `INVARIANT` and `PROPERTY` entries from the `.cfg` file — these are the safety and liveness guarantees.
+4. Read the TLA+ review consensus for any objections, caveats, or recommended changes that the experts flagged. Note these as constraints on the plan.
+
+### 2. Build the State Coverage Matrix
+
+1. List every discrete state from the TLA+ spec. A "state" is any named value in a state-set constant, any distinct configuration of the variables that the spec distinguishes, or any error/terminal condition the spec models.
+2. List every transition (named action) from the spec.
+3. List every safety invariant and liveness property.
+4. This matrix is the contract: every entry must map to at least one implementation step by the end of the process.
+
+### 3. Derive Implementation Steps
+
+For each logical unit of work, create a step. Order the steps so that each step's dependencies are satisfied by prior steps. A step is a logical unit — it may touch one file or several, but it accomplishes one coherent piece of the system.
+
+For each step, specify all of the following:
+
+- **Step number:** Sequential integer starting at 1.
+- **Title:** Short, descriptive name (e.g., "Order entity with status enum").
+- **Files:** List of files to create or modify, with absolute or repo-relative paths.
+- **Description:** Plain-language explanation of what this step accomplishes and why. Reference domain concepts from the briefing, not just technical actions.
+- **Dependencies:** List of prior step numbers this step depends on. Step 1 has no dependencies. Use `None` for steps with no dependencies other than Step 1.
+- **Test description:** The test(s) to write FIRST, before any implementation code. Describe what the test asserts, what inputs it uses, and what the expected outcome is. Be specific enough that a developer can write the test without ambiguity.
+- **TLA+ coverage:** List the specific states, transitions, and/or properties from the TLA+ spec that this step implements or enforces. Use the exact names from the spec (e.g., `SubmitOrder`, `InventoryNonNegative`, `"Paid"` state).
+
+Guidelines for step ordering:
+- Domain types and constants come first (enums, value objects, entity shells).
+- State transitions come next, ordered by the natural lifecycle (creation before mutation before termination).
+- Safety invariants are enforced within the steps that implement the transitions they guard.
+- Liveness properties translate to integration or end-to-end tests that verify eventual outcomes.
+- Infrastructure and wiring (routes, handlers, persistence) come after domain logic.
+- Each step must be independently testable. If a step cannot be tested in isolation, it is too large — split it.
+
+### 4. Self-Review — State Coverage Audit
+
+After drafting all steps, perform the coverage audit:
+
+1. For every state in the coverage matrix, confirm at least one step lists it under "TLA+ coverage." If a state is unmapped, flag it.
+2. For every transition in the coverage matrix, confirm at least one step lists it. If a transition is unmapped, flag it.
+3. For every safety invariant, confirm at least one step's test description verifies it. If an invariant is unverified, flag it.
+4. For every liveness property, confirm at least one step's test description verifies it. If a property is unverified, flag it.
+5. If any flags exist, add an "Unmapped States" section to the output listing each gap with an explanation of why it could not be mapped and a recommendation (add a step, revisit the spec, or accept as out of scope with justification).
+6. If zero flags exist, include a confirmation statement: "All TLA+ states, transitions, and properties are covered by the implementation plan."
+
+### 5. Check for Prior Versions
+
+1. Derive the topic slug from the briefing filename (e.g., `2026-03-30_order-workflow.md` yields `order-workflow`).
+2. Check `docs/implementation/` for existing files matching the slug.
+3. If a prior version exists, create a versioned filename: `YYYY-MM-DD_<slug>-v2.md`, `YYYY-MM-DD_<slug>-v3.md`, etc.
+4. If no prior version exists, use `YYYY-MM-DD_<slug>.md`.
+
+### 6. Write the Implementation Plan
+
+Save the plan to `docs/implementation/YYYY-MM-DD_<topic-slug>.md`. Create the `docs/implementation/` directory if it does not exist.
+
+## Output Format
+
+The implementation plan file uses the following structure:
+
+```markdown
+# Implementation Plan: <Topic>
+
+## Source Artifacts
+
+| Artifact | Path |
+|----------|------|
+| Briefing | `<path>` |
+| Design Consensus | `<path>` |
+| TLA+ Specification | `<path>` |
+| TLA+ Review Consensus | `<path>` |
+
+## TLA+ State Coverage Matrix
+
+### States
+<Bulleted list of every state from the spec>
+
+### Transitions
+<Bulleted list of every named action from the spec>
+
+### Safety Invariants
+<Bulleted list of every invariant from the .cfg>
+
+### Liveness Properties
+<Bulleted list of every property from the .cfg>
+
+---
+
+## Implementation Steps
+
+### Step 1: <Title>
+
+**Files:**
+- `<path/to/file>` (create | modify)
+
+**Description:**
+<Plain-language explanation of what this step does and why.>
+
+**Dependencies:** None
+
+**Test (write first):**
+<Specific test description. What to assert, what inputs to use, what the expected outcome is.>
+
+**TLA+ Coverage:**
+- State: `<state name>`
+- Transition: `<action name>`
+- Invariant: `<invariant name>`
+
+---
+
+### Step 2: <Title>
+
+**Files:**
+- `<path/to/file>` (create | modify)
+
+**Description:**
+<Plain-language explanation.>
+
+**Dependencies:** Step 1
+
+**Test (write first):**
+<Specific test description.>
+
+**TLA+ Coverage:**
+- Transition: `<action name>`
+- State: `<state name>`
+
+---
+
+<... additional steps ...>
+
+---
+
+## State Coverage Audit
+
+<Either:>
+
+All TLA+ states, transitions, and properties are covered by the implementation plan.
+
+<Or:>
+
+### Unmapped States
+
+- `<state or transition name>` — <explanation of why it is unmapped and recommendation>
+```
+
+On completion, present a summary to the caller:
+
+```
+Implementation Plan: <Topic>
+
+File created:
+  docs/implementation/YYYY-MM-DD_<slug>.md
+
+Steps: <count>
+TLA+ coverage: <count> states, <count> transitions, <count> invariants, <count> properties
+Unmapped: <count or "None">
+
+Source briefing: docs/questioner-sessions/<file>
+TLA+ spec: docs/tla-specs/<slug>/
+```
+
+## Handoff
+
+None. This agent produces the implementation plan and stops. The plan is presented to the user for review. Execution of the plan is a separate activity — this agent does not dispatch downstream agents or begin implementation.

--- a/.claude/skills/orchestrators/design-pipeline/SKILL.md
+++ b/.claude/skills/orchestrators/design-pipeline/SKILL.md
@@ -1,0 +1,361 @@
+---
+name: design-pipeline
+description: Orchestrates a strict 5-stage sequential pipeline from requirements elicitation through expert debate, TLA+ formal verification, expert review, and implementation planning. Dispatches questioner, debate-moderator, tla-writer, and implementation-writer in guaranteed order. Saves a session index to docs/design-pipeline-sessions/.
+---
+
+# Design Pipeline
+
+## Role
+
+The Design Pipeline is a state-machine orchestrator that drives a design idea through five mandatory sequential stages: requirements elicitation, expert design debate, formal TLA+ specification, expert review of that specification, and a step-by-step implementation plan. No stage can be skipped or reordered. Each stage receives the full accumulated output of every prior stage. The orchestrator itself makes no design decisions — it tracks pipeline state, passes context forward, presents user choices at error and revision points, and records everything in a session index file.
+
+No single agent can do this alone because each stage requires a different capability (interviewing, multi-expert debate, formal verification, structured planning) and the handoff contracts between them must be enforced.
+
+## When to Use
+
+- User invokes `/design-pipeline [seed]`
+- User wants a complete design-through-implementation-plan workflow with formal verification
+- Any situation where skipping stages (debate, TLA+, review) would be unacceptable
+
+## Trigger
+
+`/design-pipeline [seed]`
+
+If `seed` is provided, it is passed to the questioner as the starting context. If omitted, the questioner opens with its default question.
+
+## Pipeline Stages
+
+```
+Stage 1: Questioner           ─── elicit requirements + expert selection
+    │
+    ▼
+Stage 2: Debate-Moderator     ─── design debate with selected experts
+    │
+    ▼
+Stage 3: TLA-Writer           ─── formal TLA+ specification
+    │
+    ▼
+Stage 4: Debate-Moderator     ─── same experts review TLA+ spec
+    │
+    ▼
+Stage 5: Implementation-Writer ─── step-by-step implementation plan
+```
+
+## State Machine
+
+The orchestrator is a state machine with these states:
+
+| State | Description |
+|---|---|
+| `STAGE_1_QUESTIONER` | Eliciting requirements via questioner |
+| `STAGE_2_DESIGN_DEBATE` | Running design debate via debate-moderator |
+| `STAGE_3_TLA_WRITER` | Writing and verifying TLA+ spec |
+| `STAGE_4_TLA_REVIEW` | Running TLA+ review debate via debate-moderator |
+| `STAGE_5_IMPLEMENTATION` | Generating implementation plan |
+| `COMPLETE` | All stages finished, session file finalized |
+| `HALTED` | Pipeline stopped by user or unrecoverable error |
+
+Valid transitions:
+
+```
+STAGE_1_QUESTIONER     → STAGE_2_DESIGN_DEBATE   (questioner completes)
+STAGE_1_QUESTIONER     → HALTED                  (user abandons)
+STAGE_2_DESIGN_DEBATE  → STAGE_3_TLA_WRITER      (consensus or user accepts partial)
+STAGE_2_DESIGN_DEBATE  → HALTED                  (user stops at stalemate)
+STAGE_3_TLA_WRITER     → STAGE_4_TLA_REVIEW      (TLC passes or user accepts as-is)
+STAGE_3_TLA_WRITER     → STAGE_3_TLA_WRITER      (retry tla-writer)
+STAGE_3_TLA_WRITER     → STAGE_1_QUESTIONER       (back to questioner, restart)
+STAGE_4_TLA_REVIEW     → STAGE_5_IMPLEMENTATION   (review passes or user accepts as-is)
+STAGE_4_TLA_REVIEW     → STAGE_3_TLA_WRITER       (back to tla-writer, then re-review)
+STAGE_4_TLA_REVIEW     → STAGE_1_QUESTIONER       (back to questioner, restart)
+STAGE_5_IMPLEMENTATION → COMPLETE                 (plan delivered)
+```
+
+## Accumulated Context
+
+Every stage receives all outputs from prior stages. The orchestrator maintains an `accumulated_context` object that grows as stages complete:
+
+| After Stage | Context Contains |
+|---|---|
+| 1 | briefing, expert list |
+| 2 | briefing, expert list, design consensus synthesis |
+| 3 | briefing, expert list, design consensus, TLA+ spec + TLC results |
+| 4 | briefing, expert list, design consensus, TLA+ spec + TLC results, TLA+ review consensus |
+| 5 | all of the above + implementation plan |
+
+When a revision loop restarts from an earlier stage, outputs from that stage forward are replaced by the new outputs. Outputs from stages before the restart point are preserved.
+
+## Stage Execution
+
+### Stage 1 — Questioner
+
+Invoke the questioner skill (`.claude/skills/questioner/SKILL.md`) via the Agent tool.
+
+**Input:** User seed (if provided), plus the following role framing:
+
+```
+You are being called from the /design-pipeline orchestrator. This is a pipeline run — when you reach Phase 3 sign-off, include an "Expert Council" section listing:
+- Included experts: which experts from the debate-moderator roster should participate, with reasons
+- Excluded experts: which experts should sit out, with reasons
+
+Present the expert list during the sign-off recap for user confirmation or adjustment. Do not prompt whether the user wants expert debate — debate is mandatory in this pipeline. After sign-off, save the briefing file but do not dispatch any downstream agents. Return the briefing content and file path to the caller.
+```
+
+**Output expected:** Briefing file path + briefing content including the Expert Council section.
+
+**On completion:** Extract the expert list from the Expert Council section. Add briefing and expert list to accumulated context. Advance to `STAGE_2_DESIGN_DEBATE`.
+
+**On abandonment:** If the user stops mid-session without sign-off, the questioner saves a partial briefing marked `[INCOMPLETE]`. The orchestrator transitions to `HALTED` and records `STAGE 1 — INCOMPLETE` in the session file.
+
+### Stage 2 — Design Debate
+
+Invoke the debate-moderator skill (`.claude/skills/orchestrators/debate-moderator/SKILL.md`) via the Agent tool.
+
+**Input:**
+- **Topic:** The full briefing content from Stage 1
+- **Experts:** The expert list confirmed in Stage 1
+- **Context:** `"Debate the design described in this briefing. Focus on correctness, trade-offs, and gaps. Evaluate whether the proposed states, transitions, error handling, and scope are complete and sound."`
+
+**Output expected:** Debate synthesis (consensus or partial consensus) + session file path.
+
+**On consensus:** Add design consensus synthesis to accumulated context. Advance to `STAGE_3_TLA_WRITER`.
+
+**On partial consensus (stalemate at round 5):** Present the partial consensus to the user with:
+
+```
+The design debate ended with partial consensus after 5 rounds.
+
+Unresolved dissents:
+<list from synthesis>
+
+Options:
+  (a) Proceed to TLA+ specification with partial consensus
+  (b) Stop the pipeline here
+
+Which option?
+```
+
+If `(a)`: Add partial consensus to accumulated context. Advance to `STAGE_3_TLA_WRITER`.
+If `(b)`: Transition to `HALTED`.
+
+### Stage 3 — TLA+ Writer
+
+Invoke the tla-writer agent (`.claude/skills/tla-writer/AGENT.md`) via the Agent tool.
+
+**Input:** The briefing file path, plus the design consensus synthesis as additional context:
+
+```
+Design consensus from expert debate:
+<design consensus synthesis>
+
+Use this consensus alongside the briefing to write the TLA+ specification. The experts agreed on the above design — the spec should formally model it.
+```
+
+**Output expected:** TLA+ spec files (.tla, .cfg, README) + TLC results + output directory path.
+
+**On TLC pass:** Add TLA+ spec content and TLC results to accumulated context. Advance to `STAGE_4_TLA_REVIEW`.
+
+**On TLC failure (unresolvable after tla-writer's internal 4-tier error handling):** Present to the user:
+
+```
+TLA+ model checking failed and could not be resolved by the tla-writer.
+
+Failure details:
+<violation and counterexample from tla-writer output>
+
+Options:
+  (a) Back to questioner — restart pipeline from Stage 1 (overwrites previous outputs)
+  (b) Retry tla-writer — re-run Stage 3
+  (c) Accept as-is — proceed to TLA+ review with the unverified spec
+
+Which option?
+```
+
+If `(a)`: Reset accumulated context. Increment `restart_count` in session file. Transition to `STAGE_1_QUESTIONER`.
+If `(b)`: Increment `stage_3_retry_count` in session file. Re-run Stage 3 with the same accumulated context.
+If `(c)`: Add unverified spec to accumulated context (marked as `[UNVERIFIED]`). Advance to `STAGE_4_TLA_REVIEW`.
+
+### Stage 4 — TLA+ Review Debate
+
+Invoke the debate-moderator skill (`.claude/skills/orchestrators/debate-moderator/SKILL.md`) via the Agent tool.
+
+**Input:**
+- **Topic:** The TLA+ specification content (full .tla file) plus the briefing and design consensus
+- **Experts:** The same expert list from Stage 1
+- **Context:** `"Review this TLA+ specification against the agreed design consensus and original briefing. Focus on whether the spec correctly captures all states, transitions, safety properties, and liveness properties. Identify any states or transitions from the design that are missing from the spec, any properties that should be verified but are not, and any spec behaviors that contradict the design."`
+
+**Output expected:** Review debate synthesis + session file path.
+
+**On consensus (no objections to spec):** Add TLA+ review consensus to accumulated context. Advance to `STAGE_5_IMPLEMENTATION`.
+
+**On objections (consensus with concerns, or partial consensus):** Present to the user:
+
+```
+The TLA+ review debate raised objections:
+
+<objections from synthesis>
+
+Options:
+  (a) Back to tla-writer — revise the spec, then re-run review (Stage 3 → Stage 4)
+  (b) Back to questioner — restart pipeline from Stage 1 (overwrites previous outputs)
+  (c) Accept as-is — proceed to implementation planning
+
+Which option?
+```
+
+If `(a)`: Increment `stage_3_retry_count` in session file. Append review objections to accumulated context so tla-writer can address them. Transition to `STAGE_3_TLA_WRITER`.
+If `(b)`: Reset accumulated context. Increment `restart_count` in session file. Transition to `STAGE_1_QUESTIONER`.
+If `(c)`: Add review consensus (with objections noted) to accumulated context. Advance to `STAGE_5_IMPLEMENTATION`.
+
+### Stage 5 — Implementation Writer
+
+Invoke the implementation-writer agent (`.claude/skills/implementation-writer/AGENT.md`) via the Agent tool.
+
+**Input:** The full accumulated context:
+
+```
+Briefing:
+<briefing content>
+
+Design Consensus:
+<design consensus synthesis>
+
+TLA+ Specification:
+<.tla file content>
+
+TLC Results:
+<TLC output summary>
+
+TLA+ Review Consensus:
+<review consensus synthesis>
+
+Generate a step-by-step implementation plan. Every state and transition in the TLA+ specification must map to at least one implementation step. Flag any unmapped states before presenting the plan.
+```
+
+**Output expected:** Implementation plan saved to `docs/implementation/` + file path.
+
+**On completion:** Add implementation plan path to accumulated context. Transition to `COMPLETE`. Finalize session file.
+
+## Session File
+
+On pipeline start, create `docs/design-pipeline-sessions/YYYY-MM-DD_<topic-slug>.md`. Update it after each stage completes. The session file is an index — it does not duplicate content, only records paths and metadata.
+
+### Session File Format
+
+```markdown
+# Design Pipeline Session — <Topic>
+
+**Date:** YYYY-MM-DD
+**Status:** IN PROGRESS | COMPLETE | HALTED
+**Current Stage:** <stage name>
+**Restart Count:** <N>
+
+---
+
+## Stage 1 — Questioner
+**Status:** COMPLETE | INCOMPLETE | PENDING
+**Briefing:** `<path to briefing file>`
+**Experts Selected:** <comma-separated expert names>
+
+## Stage 2 — Design Debate
+**Status:** COMPLETE | PARTIAL CONSENSUS | PENDING
+**Synthesis:** `<path to debate session file>`
+**Rounds:** <N>
+**Result:** CONSENSUS REACHED | PARTIAL CONSENSUS
+
+## Stage 3 — TLA+ Writer
+**Status:** COMPLETE | UNVERIFIED | PENDING
+**Spec Directory:** `<path to tla-specs directory>`
+**TLC Result:** PASS | FAIL
+**Retry Count:** <N>
+
+## Stage 4 — TLA+ Review
+**Status:** COMPLETE | OBJECTIONS NOTED | PENDING
+**Synthesis:** `<path to review debate session file>`
+**Rounds:** <N>
+**Result:** CONSENSUS REACHED | PARTIAL CONSENSUS
+
+## Stage 5 — Implementation Plan
+**Status:** COMPLETE | PENDING
+**Plan:** `<path to implementation plan file>`
+**Unmapped States:** <list, or "None">
+
+---
+
+## Iteration Log
+| Iteration | From Stage | To Stage | Reason | Timestamp |
+|---|---|---|---|---|
+| 1 | 4 | 3 | Review objections — spec revision | YYYY-MM-DD HH:MM |
+```
+
+## Loop Policy
+
+There are no hard caps on revision loops. The user is the circuit breaker. The orchestrator tracks every loop iteration in the session file's Iteration Log table. Each entry records which stage triggered the loop, where it returned to, the reason, and a timestamp. This provides a full audit trail without imposing arbitrary limits.
+
+## Error Handling Summary
+
+| Stage | Error Condition | User Options |
+|---|---|---|
+| 1 | User abandons questioner | Pipeline halts. No resume. |
+| 2 | Stalemate (round 5, partial consensus) | (a) Proceed to Stage 3 with partial consensus, (b) Stop |
+| 3 | TLC failure, unresolvable | (a) Back to Stage 1, (b) Retry Stage 3, (c) Accept as-is |
+| 4 | Review produces objections | (a) Back to Stage 3 then 4, (b) Back to Stage 1, (c) Accept as-is |
+| 5 | Unmapped TLA+ states | Implementation-writer flags them; user decides whether to accept or loop back |
+
+## Output Locations
+
+Each stage saves outputs to its own directory per existing conventions:
+
+| Stage | Output Directory |
+|---|---|
+| Questioner | `docs/questioner-sessions/` |
+| Design Debate | `docs/debate-moderator-sessions/` |
+| TLA+ Writer | `docs/tla-specs/` |
+| TLA+ Review | `docs/debate-moderator-sessions/` |
+| Implementation Plan | `docs/implementation/` |
+| Pipeline Session Index | `docs/design-pipeline-sessions/` |
+
+## Handoff
+
+- **Receives from:** User (via `/design-pipeline [seed]`)
+- **Passes to:** User (final implementation plan + session index)
+- **Format:** Markdown session index file pointing to all stage outputs, plus inline summary of final results
+
+On `COMPLETE`, present to the user:
+
+```
+Design Pipeline Complete — <Topic>
+
+Session: docs/design-pipeline-sessions/YYYY-MM-DD_<topic-slug>.md
+
+Stage outputs:
+  1. Briefing:            <path>
+  2. Design Debate:       <path>
+  3. TLA+ Specification:  <path>
+  4. TLA+ Review:         <path>
+  5. Implementation Plan: <path>
+
+The implementation plan is ready for execution. Each step maps to TLA+ states and includes test descriptions (test-first per TDD).
+```
+
+On `HALTED`, present to the user:
+
+```
+Design Pipeline Halted — <Topic>
+
+Stopped at: <stage name>
+Reason: <reason>
+Session: docs/design-pipeline-sessions/YYYY-MM-DD_<topic-slug>.md
+
+Completed stage outputs are listed in the session file.
+To restart, run /design-pipeline again.
+```
+
+## Constraints
+
+- The orchestrator does not form opinions, write code, or make design decisions
+- No stage can be skipped or run out of order
+- Expert selection from Stage 1 is reused in both Stage 2 and Stage 4 — the same council reviews from start to finish
+- The orchestrator never modifies files created by downstream agents — it only creates and updates the pipeline session index
+- Sessions cannot be resumed — if halted, start a new `/design-pipeline` run
+- The orchestrator does not dispatch agents after the pipeline completes — the implementation plan is the terminal output

--- a/.claude/skills/questioner/SKILL.md
+++ b/.claude/skills/questioner/SKILL.md
@@ -43,14 +43,18 @@ Walk these branches in order. Each must be fully resolved before advancing:
 8. **Error states** — What can go wrong? How should failures surface?
 9. **Naming** — What is it called?
 10. **Scope and edge cases** — What is explicitly out of scope? Unusual inputs?
+11. **Expert council** — Based on everything above, which experts should review this design? Walk through the full list of 8 experts at `.claude/skills/agents/` (expert-tdd, expert-ddd, expert-bdd, expert-atomic-design, expert-tla, expert-performance, expert-edge-cases, expert-continuous-delivery). For each, recommend include or exclude with a one-sentence reason. Present the full recommendation to the user for confirmation or adjustment.
 
 ## Phase 3 — Sign-Off
 
 When all branches are resolved:
 
-1. Produce a concise **recap** covering: purpose, artifact type, trigger, inputs, outputs, handoff (if applicable), name, and scope. One screen maximum.
-2. Ask explicitly: **"Does this match what you want? Say yes to proceed."**
+1. Produce a concise **recap** covering: purpose, artifact type, trigger, inputs, outputs, handoff (if applicable), name, scope, and **expert council recommendation** (included experts with reasons, excluded experts with reasons). One screen maximum.
+2. Ask explicitly: **"Does this match what you want? Would you like to adjust the expert list? Say yes to proceed."**
 3. Do not write the briefing file or dispatch any agents until the user confirms with a clear yes.
+4. After the recap is confirmed, ask: **"Would you like this to go through expert debate before proceeding?"**
+   - When invoked from `/design-pipeline`: skip this prompt — debate is always yes.
+   - When invoked standalone: the user decides yes or no.
 
 ## Phase 4 — Save and Dispatch
 
@@ -76,6 +80,8 @@ After sign-off:
 | User rejects all proposed targets | Ask directly which skill they want to hand off to |
 | User stops mid-session without sign-off | Save partial briefing marked `[INCOMPLETE]` to session file, then stop |
 | Multiple valid downstream targets | Propose all; dispatch in parallel after user confirms |
+| Invoked from `/design-pipeline` | Debate is always yes — skip the debate prompt in Phase 3, record `Yes` in session file |
+| User adjusts expert list during sign-off | Update the recommendation to match; re-confirm before proceeding |
 
 ## Output Format
 
@@ -122,6 +128,16 @@ After sign-off:
 
 ## Edge Cases
 <unusual inputs, boundary conditions>
+
+## Expert Council
+### Included
+- expert-name — reason for inclusion
+
+### Excluded
+- expert-name — reason for exclusion
+
+## Debate Requested
+Yes / No
 
 ---
 

--- a/docs/questioner-sessions/2026-03-30_design-pipeline-orchestrator.md
+++ b/docs/questioner-sessions/2026-03-30_design-pipeline-orchestrator.md
@@ -1,0 +1,148 @@
+# Questioner Session — Design Pipeline Orchestrator
+
+**Date:** 2026-03-30
+**Status:** COMPLETE
+**Dispatched to:** trainer (x2: design-pipeline orchestrator + implementation-writer agent), questioner modification
+
+---
+
+## Purpose
+Guaranteed sequential pipeline that takes a design idea from requirements elicitation through expert debate, formal TLA+ verification, expert review of the spec, and finally to a step-by-step implementation plan. No stage can be skipped or run out of order. Solves the problem of ad-hoc, inconsistent design workflows where steps get missed.
+
+## Artifact / Output Type
+Two artifacts:
+1. **Orchestrator skill** — `/design-pipeline` (SKILL.md) at `.claude/skills/orchestrators/design-pipeline/SKILL.md`
+2. **Internal agent** — `implementation-writer` (AGENT.md) at `.claude/skills/implementation-writer/AGENT.md`
+
+Plus a modification to the existing questioner to add expert council selection.
+
+## Trigger
+`/design-pipeline [seed]` where seed is optional. If no seed, the questioner phase asks the opening question.
+
+## Inputs
+- User seed (optional text) passed to questioner
+- Each subsequent stage receives the accumulated outputs of all prior stages
+
+## Outputs
+
+### Pipeline session file
+`docs/design-pipeline-sessions/YYYY-MM-DD_<topic-slug>.md` — master index tracking all 5 stages, pointing to individual stage outputs.
+
+### Individual stage outputs (saved to existing locations)
+- `docs/questioner-sessions/` — briefing with expert council section
+- `docs/debate-moderator-sessions/` — both debate syntheses (design + TLA+ review)
+- `docs/tla-specs/` — TLA+ spec (.tla, .cfg, README)
+- `docs/implementation/` — step-by-step implementation plan
+
+### Implementation plan format
+Ordered steps, each specifying:
+- File(s) to create or modify
+- What the change does (plain language)
+- Which prior step it depends on
+- Test description (test to write first, per TDD)
+- Explicit mapping to TLA+ states covered by this step
+
+## Ecosystem Placement
+Chain — `/design-pipeline` orchestrates the full sequence. All existing skills remain independently callable.
+
+## Handoff
+
+### Complete data flow
+```
+Stage 1: /questioner
+  Input:  user seed
+  Output: briefing + expert list (included/excluded with reasons)
+
+Stage 2: /debate-moderator (design debate)
+  Input:  briefing + selected experts
+  Context: "Debate the design described in this briefing. Focus on correctness, trade-offs, and gaps."
+  Output: design consensus synthesis
+
+Stage 3: /tla-writer
+  Input:  briefing + design consensus
+  Output: .tla spec + .cfg + TLC results + README
+
+Stage 4: /debate-moderator (TLA+ review, SAME experts)
+  Input:  briefing + design consensus + TLA+ output
+  Context: "Review this TLA+ specification against the agreed design consensus. Focus on whether the spec correctly captures all states, transitions, and safety properties."
+  Output: TLA+ review consensus
+
+Stage 5: /implementation-writer
+  Input:  briefing + design consensus + TLA+ spec + TLA+ review consensus
+  Output: step-by-step implementation plan in docs/implementation/
+```
+
+### Questioner modifications
+- Add "Expert Council" section to Phase 3 output:
+  - Included experts with reasons
+  - Excluded experts with reasons
+- Add debate prompt: "Would you like this to go through expert debate?"
+- When called from /design-pipeline, debate is always yes (skip the prompt)
+- When called standalone, debate is optional (user decides)
+- Expert list presented during sign-off recap for user confirmation/adjustment
+
+## Error States
+
+### Stage 1 — Questioner abandons
+Pipeline halts. Session file saved with `STAGE 1 — INCOMPLETE`. No resume; start fresh.
+
+### Stage 2 — Debate stalemate (round 5, partial consensus)
+Pipeline pauses. User decides: proceed to TLA+ with partial consensus, or stop.
+
+### Stage 3 — TLA+ model check failure
+TLA-writer's existing 4-tier error handling plays out first. If ultimately unresolvable, user chooses:
+- (a) Back to questioner → restart pipeline from Stage 1, overwrite previous docs
+- (b) Retry tla-writer → re-run Stage 3
+- (c) Accept as-is → proceed to Stage 4
+
+### Stage 4 — TLA+ review produces objections
+User chooses:
+- (a) Back to tla-writer → re-run Stage 3 then Stage 4
+- (b) Back to questioner → restart pipeline from Stage 1, overwrite previous docs
+- (c) Accept as-is → proceed to Stage 5
+
+### Loop policy
+No hard caps on revision loops. User is the circuit breaker. Orchestrator tracks iteration count in session file.
+
+### Stage 5 — Implementation-writer self-review
+Lists every state from the TLA+ spec and maps it to a step. Flags any unmapped state before presenting the plan.
+
+## Name
+- Orchestrator: `design-pipeline`
+- Implementation agent: `implementation-writer`
+
+## Scope
+
+### In scope
+- Orchestrating the 5-stage sequential pipeline
+- Passing accumulated context between stages
+- Presenting user choices at error/loop points
+- Tracking pipeline state in session file
+
+### Out of scope
+- Writing code — produces implementation plan only
+- Executing the implementation plan
+- Modifying existing skills (questioner changes are a separate task)
+- Creating new expert agents — works with existing 8 experts
+- Monitoring downstream agents after dispatch
+- Resuming interrupted sessions — always start fresh
+- Hard caps on revision loops
+
+## Edge Cases
+
+### Questioner called standalone vs. from pipeline
+- Standalone: expert council section included but debate is optional
+- From pipeline: debate is always yes, no prompt needed
+
+### Second debate differentiation
+- Orchestrator passes different `--context` role framing for each debate round
+- Debate-moderator itself needs no changes — `--context` parameter is sufficient
+
+### Pipeline session as index
+- Pipeline session file does not duplicate content — it indexes paths to individual stage outputs
+- Each stage still saves to its own directory per existing conventions
+
+---
+
+## Open Questions
+None — all branches resolved.


### PR DESCRIPTION
## Summary
- Add `/design-pipeline` orchestrator — a guaranteed 5-stage sequential pipeline (questioner → debate → TLA+ → debate review → implementation plan) with no skippable stages
- Add `implementation-writer` internal agent — final pipeline stage that produces TDD-first implementation plans with full TLA+ state coverage audit
- Update `/questioner` with expert council selection (branch 11: include/exclude with reasons) and debate prompt (always yes from pipeline, optional standalone)

## Test plan
- [ ] Invoke `/design-pipeline test-feature` and verify all 5 stages execute in order
- [ ] Invoke `/questioner` standalone and verify expert council section appears in output
- [ ] Verify debate prompt is skipped when questioner is called from pipeline context
- [ ] Verify implementation-writer flags unmapped TLA+ states in self-review
- [ ] Test error paths: abandon at stage 1, stalemate at stage 2, TLA+ failure at stage 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)