### PR TITLE
feat: global pipeline state file for cross-agent shared state

### DIFF
--- a/.claude/skills/design-pipeline/SKILL.md
+++ b/.claude/skills/design-pipeline/SKILL.md
@@ -26,7 +26,7 @@ If `seed` is provided, it is passed to the questioner as the starting context. I
 ## Pipeline Stages
 
 ```
-Stage 1: Questioner            ─── elicit requirements + expert selection
+Stage 1: Questioner            ─── elicit requirements
     │
     ▼
 Stage 2: Debate-Moderator      ─── design debate with selected experts
@@ -134,10 +134,10 @@ Every stage receives all outputs from prior stages. The orchestrator maintains a
 
 | After Stage | Context Contains |
 |---|---|
-| 1 | briefing, expert list |
-| 2 | briefing, expert list, design consensus synthesis |
-| 3 | briefing, expert list, design consensus, TLA+ spec + TLC results |
-| 4 | briefing, expert list, design consensus, TLA+ spec + TLC results, TLA+ review consensus |
+| 1 | briefing |
+| 2 | briefing, design consensus synthesis |
+| 3 | briefing, design consensus, TLA+ spec + TLC results |
+| 4 | briefing, design consensus, TLA+ spec + TLC results, TLA+ review consensus |
 | 5 | all of the above + implementation plan (with execution tiers + task assignment table) |
 | 6 | all of the above + committed code on named branch (terminal artifact) |
 
@@ -152,16 +152,12 @@ Invoke the questioner skill (`.claude/skills/questioner/SKILL.md`) via the Agent
 **Input:** User seed (if provided), plus the following role framing:
 
 ```
-You are being called from the /design-pipeline orchestrator. This is a pipeline run — when you reach Phase 3 sign-off, include an "Expert Council" section listing:
-- Included experts: which experts from the debate-moderator roster should participate, with reasons
-- Excluded experts: which experts should sit out, with reasons
-
-Present the expert list during the sign-off recap for user confirmation or adjustment. Do not prompt whether the user wants expert debate — debate is mandatory in this pipeline. After sign-off, save the briefing file but do not dispatch any downstream agents. Return the briefing content and file path to the caller.
+You are being called from the /design-pipeline orchestrator. This is a pipeline run. After sign-off, save the briefing file but do not dispatch any downstream agents. Return the briefing content and file path to the caller.
 ```
 
-**Output expected:** Briefing file path + briefing content including the Expert Council section.
+**Output expected:** Briefing file path + briefing content.
 
-**On completion:** Extract the expert list from the Expert Council section. Add briefing and expert list to accumulated context. Advance to `STAGE_2_DESIGN_DEBATE`.
+**On completion:** Add briefing to accumulated context. Advance to `STAGE_2_DESIGN_DEBATE`.
 
 **On abandonment:** If the user stops mid-session without sign-off, the questioner saves a partial briefing marked `[INCOMPLETE]`. The orchestrator transitions to `HALTED` and records `STAGE 1 — INCOMPLETE` in the session file.
 
@@ -171,7 +167,6 @@ Invoke the debate-moderator skill (`.claude/skills/orchestrators/debate-moderato
 
 **Input:**
 - **Topic:** The full briefing content from Stage 1
-- **Experts:** The expert list confirmed in Stage 1
 - **Context:** `"Debate the design described in this briefing. Focus on correctness, trade-offs, and gaps. Evaluate whether the proposed states, transitions, error handling, and scope are complete and sound."`
 
 **Output expected:** Debate synthesis (consensus or partial consensus) + session file path.
@@ -239,7 +234,6 @@ Invoke the debate-moderator skill (`.claude/skills/orchestrators/debate-moderato
 
 **Input:**
 - **Topic:** The TLA+ specification content (full .tla file) plus the briefing and design consensus
-- **Experts:** The same expert list from Stage 1
 - **Context:** `"Review this TLA+ specification against the agreed design consensus and original briefing. Focus on whether the spec correctly captures all states, transitions, safety properties, and liveness properties. Identify any states or transitions from the design that are missing from the spec, any properties that should be verified but are not, and any spec behaviors that contradict the design."`
 
 **Output expected:** Review debate synthesis + session file path.
@@ -710,7 +704,6 @@ To restart, run /design-pipeline again.
 
 - The orchestrator does not form opinions, write code, or make design decisions
 - No stage can be skipped or run out of order
-- Expert selection from Stage 1 is reused in both Stage 2 and Stage 4 -- the same council reviews from start to finish
 - The orchestrator never modifies files created by downstream agents -- it only creates and updates the pipeline session index
 - Sessions cannot be resumed -- if halted, start a new `/design-pipeline` run
 - Stage 6 requires user confirmation before any autonomous work begins (confirmation gate)

--- a/.claude/skills/design-pipeline/SKILL.md
+++ b/.claude/skills/design-pipeline/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: design-pipeline
-description: Orchestrates a strict 6-stage sequential pipeline from requirements elicitation through expert debate, TLA+ formal verification, expert review, implementation planning, and autonomous pair programming execution. Dispatches questioner, debate-moderator, tla-writer, implementation-writer, and writer agent pairs in guaranteed order. Saves a session index to docs/design-pipeline-sessions/.
+description: Orchestrates a strict 6-stage sequential pipeline from requirements elicitation through expert debate, TLA+ formal verification, expert review, implementation planning, and autonomous pair programming execution. Dispatches questioner, debate-moderator, tla-writer, implementation-writer, and writer agent pairs in guaranteed order.
 ---
 
 # Design Pipeline
 
 ## Role
 
-The Design Pipeline is a state-machine orchestrator that drives a design idea through six mandatory sequential stages: requirements elicitation, expert design debate, formal TLA+ specification, expert review of that specification, a step-by-step implementation plan, and autonomous pair programming execution. No stage can be skipped or reordered. Each stage receives the full accumulated output of every prior stage. The orchestrator itself makes no design decisions -- it tracks pipeline state, passes context forward, presents user choices at error and revision points, and records everything in a session index file.
+The Design Pipeline is a state-machine orchestrator that drives a design idea through six mandatory sequential stages: requirements elicitation, expert design debate, formal TLA+ specification, expert review of that specification, a step-by-step implementation plan, and autonomous pair programming execution. No stage can be skipped or reordered. Each stage receives the full accumulated output of every prior stage. The orchestrator itself makes no design decisions -- it tracks pipeline state, passes context forward, and presents user choices at error and revision points.
 
 No single agent can do this alone because each stage requires a different capability (interviewing, multi-expert debate, formal verification, structured planning, parallel TDD execution) and the handoff contracts between them must be enforced.
 
@@ -115,33 +115,29 @@ STAGE_6_GLOBAL_REVIEW           → HALTED                        (fails, cap re
 STAGE_6_FIX_SESSION             → STAGE_6_GLOBAL_REVIEW          (fix done — FixSessionComplete)
 ```
 
-## Pipeline Change Tracking
+## Pipeline State File
 
-The orchestrator tracks structural pipeline changes using a `changeFlag` boolean:
+**Location:** `docs/pipeline-state.md` -- the single source of truth for live pipeline state. Replaces the former session index.
 
-- `changeFlag` starts `FALSE` at the beginning of each pipeline run
-- Any stage that modifies pipeline structure sets `changeFlag = TRUE`. Structural changes include:
-  - A new expert is added to the roster
-  - A stage's role or responsibilities change
-  - A new stage is added or removed
-  - Stage ordering changes
-- `changeFlag` is checked once at Stage 6 completion
-- **At most one structural change is captured per write cycle.** Subsequent structural changes during an active `.puml` update (PENDING/WRITING states) are silently dropped. This is an explicit design simplification documented in the TLA+ spec (`PipelineImprovements.tla`, Machine 3).
+### Clear on Start
 
-## Accumulated Context
+At the start of each pipeline run, overwrite the state file with the template (CLEARED state). The template contains section headers for each stage with empty values. If the clear operation fails (disk full, permission error, file locked), do not start the pipeline -- fail-fast.
 
-Every stage receives all outputs from prior stages. The orchestrator maintains an `accumulated_context` object that grows as stages complete:
+### Uncommitted-Change Warning
 
-| After Stage | Context Contains |
-|---|---|
-| 1 | briefing |
-| 2 | briefing, design consensus synthesis |
-| 3 | briefing, design consensus, TLA+ spec + TLC results |
-| 4 | briefing, design consensus, TLA+ spec + TLC results, TLA+ review consensus |
-| 5 | all of the above + implementation plan (with execution tiers + task assignment table) |
-| 6 | all of the above + committed code on named branch (terminal artifact) |
+Before clearing, check `git status` on the state file. If there are uncommitted changes, warn the user. Do not block -- warn only.
 
-When a revision loop restarts from an earlier stage, outputs from that stage forward are replaced by the new outputs. Outputs from stages before the restart point are preserved.
+### Section-Scoped Ownership
+
+Each stage writes only its own StageResult section. Cross-section writes are domain invariant violations. The orchestrator writes only the run-level metadata and the Git section.
+
+### Schema Validation
+
+Each stage validates that the state file is well-formed (all prior StageResult sections are present and parseable) before writing its own section.
+
+### Terminal-State-Only Commits
+
+The state file is committed only when the pipeline reaches a terminal state (COMPLETE or HALTED). Intermediate states are transient and not committed. One meaningful commit per pipeline run.
 
 ## Stage Execution
 
@@ -159,7 +155,7 @@ You are being called from the /design-pipeline orchestrator. This is a pipeline 
 
 **On completion:** Add briefing to accumulated context. Advance to `STAGE_2_DESIGN_DEBATE`.
 
-**On abandonment:** If the user stops mid-session without sign-off, the questioner saves a partial briefing marked `[INCOMPLETE]`. The orchestrator transitions to `HALTED` and records `STAGE 1 — INCOMPLETE` in the session file.
+**On abandonment:** If the user stops mid-session without sign-off, the questioner saves a partial briefing marked `[INCOMPLETE]`. The orchestrator transitions to `HALTED`.
 
 ### Stage 2 — Design Debate
 
@@ -224,8 +220,8 @@ Options:
 Which option?
 ```
 
-If `(a)`: Reset accumulated context. Increment `restart_count` in session file. Transition to `STAGE_1_QUESTIONER`.
-If `(b)`: Increment `stage_3_retry_count` in session file. Re-run Stage 3 with the same accumulated context.
+If `(a)`: Reset accumulated context. Transition to `STAGE_1_QUESTIONER`.
+If `(b)`: Re-run Stage 3 with the same accumulated context.
 If `(c)`: Add unverified spec to accumulated context (marked as `[UNVERIFIED]`). Advance to `STAGE_4_TLA_REVIEW`.
 
 ### Stage 4 — TLA+ Review Debate
@@ -255,8 +251,8 @@ Options:
 Which option?
 ```
 
-If `(a)`: Increment `stage_3_retry_count` in session file. Append review objections to accumulated context so tla-writer can address them. Transition to `STAGE_3_TLA_WRITER`.
-If `(b)`: Reset accumulated context. Increment `restart_count` in session file. Transition to `STAGE_1_QUESTIONER`.
+If `(a)`: Append review objections to accumulated context so tla-writer can address them. Transition to `STAGE_3_TLA_WRITER`.
+If `(b)`: Reset accumulated context. Transition to `STAGE_1_QUESTIONER`.
 If `(c)`: Add review consensus (with objections noted) to accumulated context. Advance to `STAGE_5_IMPLEMENTATION`.
 
 ### Stage 5 — Implementation Writer
@@ -293,6 +289,13 @@ Generate a step-by-step implementation plan. Every state and transition in the T
 Stage 6 is a multi-phase autonomous execution stage. It reads the implementation plan from Stage 5 (including execution tiers and task assignments) and executes the plan using parallel pair programming sessions. The orchestrator manages worktrees, dispatches agent pairs, enforces TDD discipline, serializes merges, and runs cross-tier verification.
 
 **TLA+ Specification:** `docs/tla-specs/pair-programming-stage/PairProgrammingStage.tla`
+
+#### Stage 6 State File Updates
+
+1. After the confirmation gate is passed (user confirms), write the Stage 6 StageResult to `docs/pipeline-state.md` with **Status:** `IN PROGRESS`, **Artifact:** the integration branch name (`design-pipeline/<topic-slug>`), and **Timestamp:** the current ISO-8601 timestamp.
+2. Before writing, validate that all prior StageResult sections (Stages 1-5) are populated. If any prior section is missing or empty, halt with a schema validation error -- do not write Stage 6.
+3. Write only to the Stage 6 section -- section-scoped ownership applies. Do not modify any other stage's section.
+4. Update the Stage 6 Status throughout execution: `IN PROGRESS` during tier execution, `COMPLETE` on success, `HALTED` on failure.
 
 #### 6a. Confirmation Gate (STAGE_6_CONFIRMATION_GATE)
 
@@ -489,11 +492,13 @@ Spawn a targeted fix session for the failing issue:
 
 #### 6g. Terminal Artifact
 
-On `COMPLETE`, the terminal artifact is a commit on the named branch `design-pipeline/<topic-slug>`. This is durable -- a crash or timeout cannot lose the work.
+On `COMPLETE`, the terminal artifact is a commit on the named branch `design-pipeline/<topic-slug>`. This is durable -- a crash or timeout cannot lose the work. Commit `docs/pipeline-state.md` as part of the terminal artifact. The state file records the final pipeline state for archival via git history.
 
-**Invariant enforced:** `HaltReasonConsistent` -- when HALTED, haltReason is always set to a non-NONE value.
+**Invariant enforced:** `HaltReasonConsistent` -- when HALTED, haltReason is always set to a non-NONE value. Commit `docs/pipeline-state.md` with the HALTED status and halt reason. The state file records why the pipeline stopped.
 
 ### PlantUML Diagram Update
+
+The orchestrator tracks structural pipeline changes using a `changeFlag` boolean. `changeFlag` starts `FALSE` at the beginning of each pipeline run. Any stage that modifies pipeline structure sets `changeFlag = TRUE`. Structural changes include: a new expert is added to the roster, a stage role or responsibilities change, a new stage is added or removed, or stage ordering changes. **At most one structural change is captured per write cycle.** Subsequent structural changes during an active `.puml` update are silently dropped.
 
 At pipeline completion (`COMPLETE` state), if `changeFlag = TRUE`:
 
@@ -548,82 +553,9 @@ At pipeline completion (`COMPLETE` state), if `changeFlag = TRUE`:
 | `PipelineTerminates` | Confirmed pipeline eventually reaches COMPLETE or HALTED |
 | `MergeQueueProgress` | Every QUEUED merge eventually reaches MERGE_COMPLETE, MERGE_CONFLICT, or HALTED |
 
-## Session File
-
-On pipeline start, create `docs/design-pipeline-sessions/YYYY-MM-DD_<topic-slug>.md`. Update it after each stage completes. The session file is an index — it does not duplicate content, only records paths and metadata.
-
-### Session File Format
-
-```markdown
-# Design Pipeline Session — <Topic>
-
-**Date:** YYYY-MM-DD
-**Status:** IN PROGRESS | COMPLETE | HALTED
-**Current Stage:** <stage name>
-**Restart Count:** <N>
-
----
-
-## Stage 1 — Questioner
-**Status:** COMPLETE | INCOMPLETE | PENDING
-**Briefing:** `<path to briefing file>`
-**Experts Selected:** <comma-separated expert names>
-
-## Stage 2 — Design Debate
-**Status:** COMPLETE | PARTIAL CONSENSUS | PENDING
-**Synthesis:** `<path to debate session file>`
-**Rounds:** <N>
-**Result:** CONSENSUS REACHED | PARTIAL CONSENSUS
-
-## Stage 3 — TLA+ Writer
-**Status:** COMPLETE | UNVERIFIED | PENDING
-**Spec Directory:** `<path to tla-specs directory>`
-**TLC Result:** PASS | FAIL
-**Retry Count:** <N>
-
-## Stage 4 — TLA+ Review
-**Status:** COMPLETE | OBJECTIONS NOTED | PENDING
-**Synthesis:** `<path to review debate session file>`
-**Rounds:** <N>
-**Result:** CONSENSUS REACHED | PARTIAL CONSENSUS
-
-## Stage 5 — Implementation Plan
-**Status:** COMPLETE | PENDING
-**Plan:** `<path to implementation plan file>`
-**Unmapped States:** <list, or "None">
-**Tiers:** <N>
-**Tasks:** <N>
-
-## Stage 6 — Pair Programming
-**Status:** COMPLETE | IN PROGRESS | HALTED | PENDING
-**Integration Branch:** `design-pipeline/<topic-slug>`
-**Current Tier:** <N of M>
-**Current Pipeline State:** <STAGE_6 sub-state>
-**Global Fix Count:** <N of MaxGlobalFixes>
-**Halt Reason:** <reason, or "N/A">
-
-### Tier Progress
-| Tier | Tasks | Dispatched | Complete | Failed | Merged | Status |
-|---|---|---|---|---|---|---|
-| 1 | 7 | 7 | 6 | 1 | 6 | VERIFIED |
-| 2 | 3 | 3 | 3 | 0 | 3 | MERGING |
-
-### Session Log
-| Task ID | Tier | Code Writer | Test Writer | TDD Cycles | Commits | Status | Re-dispatches |
-|---|---|---|---|---|---|---|---|
-| T1 | 1 | typescript-writer | vitest-writer | 5 | 5 | SESSION_COMPLETE | 0 |
-
----
-
-## Iteration Log
-| Iteration | From Stage | To Stage | Reason | Timestamp |
-|---|---|---|---|---|
-| 1 | 4 | 3 | Review objections — spec revision | YYYY-MM-DD HH:MM |
-```
-
 ## Loop Policy
 
-There are no hard caps on revision loops. The user is the circuit breaker. The orchestrator tracks every loop iteration in the session file's Iteration Log table. Each entry records which stage triggered the loop, where it returned to, the reason, and a timestamp. This provides a full audit trail without imposing arbitrary limits.
+There are no hard caps on revision loops. The user is the circuit breaker. The orchestrator tracks every loop iteration. Each entry records which stage triggered the loop, where it returned to, the reason, and a timestamp. This provides a full audit trail without imposing arbitrary limits.
 
 ## Error Handling Summary
 
@@ -653,20 +585,18 @@ Each stage saves outputs to its own directory per existing conventions:
 | TLA+ Review | `docs/debate-moderator-sessions/` |
 | Implementation Plan | `docs/implementation/` |
 | Pair Programming | Named branch: `design-pipeline/<topic-slug>` |
-| Pipeline Session Index | `docs/design-pipeline-sessions/` |
+| Pipeline State | `docs/pipeline-state.md` |
 
 ## Handoff
 
 - **Receives from:** User (via `/design-pipeline [seed]`)
-- **Passes to:** User (committed code on named branch + session index)
-- **Format:** Markdown session index file pointing to all stage outputs, plus inline summary of final results
+- **Passes to:** User (committed code on named branch)
+- **Format:** Inline summary of final results pointing to all stage outputs
 
 On `COMPLETE`, present to the user:
 
 ```
 Design Pipeline Complete — <Topic>
-
-Session: docs/design-pipeline-sessions/YYYY-MM-DD_<topic-slug>.md
 
 Stage outputs:
   1. Briefing:            <path>
@@ -682,6 +612,8 @@ Total TDD cycles: <N>
 Total commits: <N>
 Global fix iterations: <N of 3>
 
+State file: docs/pipeline-state.md
+
 All code is committed on branch design-pipeline/<topic-slug>.
 All tests, type-check, and lint pass. TLA+ coverage audit passed.
 ```
@@ -693,9 +625,9 @@ Design Pipeline Halted — <Topic>
 
 Stopped at: <stage name and sub-state>
 Halt reason: <TIER_ALL_FAILED | VERIFICATION_FAILED | GLOBAL_REVIEW_EXHAUSTED | MERGE_CONFLICT_UNRESOLVABLE | user rejection>
-Session: docs/design-pipeline-sessions/YYYY-MM-DD_<topic-slug>.md
 
-Completed stage outputs are listed in the session file.
+Completed stage outputs are listed above.
+State file: docs/pipeline-state.md
 Partial work (if any) is on branch: design-pipeline/<topic-slug>
 To restart, run /design-pipeline again.
 ```
@@ -704,7 +636,7 @@ To restart, run /design-pipeline again.
 
 - The orchestrator does not form opinions, write code, or make design decisions
 - No stage can be skipped or run out of order
-- The orchestrator never modifies files created by downstream agents -- it only creates and updates the pipeline session index
+- The orchestrator never modifies files created by downstream agents
 - Sessions cannot be resumed -- if halted, start a new `/design-pipeline` run
 - Stage 6 requires user confirmation before any autonomous work begins (confirmation gate)
 - Maximum 3 concurrent worktrees on Windows (MaxConcurrent = 3)

--- a/.claude/skills/implementation-writer/AGENT.md
+++ b/.claude/skills/implementation-writer/AGENT.md
@@ -278,6 +278,21 @@ Source briefing: docs/questioner-sessions/<file>
 TLA+ spec: docs/tla-specs/<slug>/
 ```
 
+## Pipeline State File
+
+When called from the design pipeline, the implementation-writer writes its results to the global state file. These instructions are conditional — they apply only when the pipeline context is detected.
+
+**Detection:** The implementation-writer knows it is in a pipeline run when `docs/pipeline-state.md` exists and the run-level Status is `ACCUMULATING`.
+
+**Pre-Write Validation:** Before writing, validate that Stage 1, Stage 2, Stage 3, and Stage 4 StageResult sections in `docs/pipeline-state.md` are populated (Status is not empty). If any prior stage is missing or has an empty Status, report the validation error to the caller and do not write.
+
+**Writing the Stage 5 StageResult:** After completing the implementation plan (Process step 6), update the Stage 5 section in `docs/pipeline-state.md` with:
+- **Status:** `COMPLETE`
+- **Artifact:** the implementation plan file path (e.g., `docs/implementation/YYYY-MM-DD_<slug>.md`)
+- **Timestamp:** current date/time
+
+**Section-Scoped Ownership:** Write only to the Stage 5 section. Do not modify any other stage's section, the run metadata, or the Git section. Cross-section writes are domain invariant violations.
+
 ## Handoff
 
 - **Passes to:** design-pipeline Stage 6 orchestrator (via the design-pipeline SKILL.md)

--- a/.claude/skills/orchestrators/debate-moderator/SKILL.md
+++ b/.claude/skills/orchestrators/debate-moderator/SKILL.md
@@ -179,6 +179,25 @@ After the synthesis is written and the session file is saved, check whether any 
   source_session: <session filename>
 ```
 
+## Pipeline State File
+
+When called from the design pipeline, the debate-moderator writes its StageResult to `docs/pipeline-state.md`. These instructions are conditional — they apply only when a pipeline run is active. The debate-moderator is also used standalone, in which case this section does not apply.
+
+**Detection:** The debate-moderator knows it is in a pipeline run when `docs/pipeline-state.md` exists and the run-level Status is `ACCUMULATING`. The caller (design-pipeline orchestrator) indicates which stage this debate is for: Stage 2 (Design Debate) or Stage 4 (TLA+ Review).
+
+**Pre-Write Validation:** Before writing a StageResult section, validate that all prior StageResult sections are populated:
+- For Stage 2: validate the Stage 1 StageResult is populated.
+- For Stage 4: validate the Stages 1, 2, and 3 StageResult sections are populated.
+
+If validation fails, report the error to the caller and do not write. Do not attempt to fill in missing prior stages.
+
+**Writing the StageResult:** After the synthesis is written and the session file is saved, update the appropriate stage section in `docs/pipeline-state.md`:
+- **Status:** `CONSENSUS REACHED` or `PARTIAL CONSENSUS`
+- **Artifact:** the debate session file path (e.g., `docs/debate-moderator-sessions/YYYY-MM-DD_<topic-slug>.md`)
+- **Timestamp:** current date/time
+
+**Section-Scoped Ownership:** Write only to the assigned stage's section (Stage 2 or Stage 4, as indicated by the caller). Do not modify any other stage's section, the run metadata, or the Git section. Cross-section writes are domain invariant violations.
+
 ## Constraints
 
 - The moderator does not form opinions, edit files, or cast deciding votes

--- a/.claude/skills/questioner/SKILL.md
+++ b/.claude/skills/questioner/SKILL.md
@@ -70,6 +70,23 @@ After sign-off:
    - The path to the saved `.md` file
 5. Once dispatched, the Questioner's job is done.
 
+
+## Pipeline State File
+
+When the questioner is called as part of a design pipeline run, it must write its Stage 1 results to `docs/pipeline-state.md` after saving the briefing file.
+
+**Detection:** The questioner knows it is in a pipeline run when `docs/pipeline-state.md` exists and the run-level **Status:** is `CLEARED` or `ACCUMULATING`. When invoked standalone (no state file or status is not `CLEARED`/`ACCUMULATING`), skip this section entirely.
+
+**After saving the briefing file, write the Stage 1 StageResult:**
+
+1. Check that `docs/pipeline-state.md` exists and contains the expected template structure before writing. If the file does not exist or is malformed, log a warning and skip the state file update.
+2. Update the `## Stage 1 — Questioner` section with:
+   - **Status:** `COMPLETE` (or `INCOMPLETE` if sign-off was not reached)
+   - **Artifact:** the briefing file path (e.g., `docs/questioner-sessions/2026-04-02_payment-flow.md`)
+   - **Timestamp:** current date/time in ISO 8601 format
+3. Write only to the Stage 1 section — do not modify any other stage section (section-scoped ownership).
+4. If sign-off was not reached and the session is incomplete, set **Status:** to `INCOMPLETE` and still record the partial artifact path and timestamp.
+
 ## Decision Guide
 
 | Situation | Recommended action |

--- a/.claude/skills/tla-writer/AGENT.md
+++ b/.claude/skills/tla-writer/AGENT.md
@@ -182,6 +182,30 @@ TLC Result: FAIL
 Action needed: <specific question for the user about the design>
 ```
 
+## Pipeline State File
+
+When called from the design pipeline, the tla-writer writes its results to the global state file at `docs/pipeline-state.md`.
+
+### Detection
+
+The tla-writer knows it is in a pipeline run when `docs/pipeline-state.md` exists and the run-level Status is `ACCUMULATING`.
+
+### Pre-Write Validation
+
+Before writing, validate that Stage 1 and Stage 2 StageResult sections in `docs/pipeline-state.md` are populated (Status is not empty). If validation fails, report the error to the caller — do not write a Stage 3 result on top of missing prior stages.
+
+### Writing the Stage 3 StageResult
+
+After completing the TLA+ specification (Process step 5 or after error handling), update the Stage 3 section in `docs/pipeline-state.md` with:
+
+- **Status:** `COMPLETE` (TLC passed) or `UNVERIFIED` (TLC failed and user accepted as-is)
+- **Artifact:** the TLA+ spec directory path (e.g., `docs/tla-specs/<slug>/`)
+- **Timestamp:** current date/time
+
+### Section-Scoped Ownership
+
+Write only to the Stage 3 section. Do not modify any other stage's section, the run metadata, or the Git section. Cross-section writes are domain invariant violations.
+
 ## Handoff
 
 None. This agent verifies and stops. Results are presented to the user. No downstream agent is dispatched.

--- a/ai-adventures.md
+++ b/ai-adventures.md
@@ -1,0 +1,27 @@
+Questioner: Does this look right? Any changes to the expert list or design decisions before I launch the debate?
+User: remember, the questioner no longer choose and confirms the expert council, is this still in your instructions? It's handled by the debate moderator,     
+confirm that's the case
+
+Questioner: Good catch — let me verify both files to confirm the current state.
+
+Questioner: Confirmed — the code is already correct:
+
+- Questioner (SKILL.md line 8): explicitly states it handles branches 1–10 only and "does not curate the expert council — that responsibility belongs to
+  downstream pipeline stages."
+- Debate-moderator (SKILL.md): has the Autonomous Expert Selection section with selectExperts(topic) — it picks experts autonomously when no --experts
+  argument is provided.
+
+The bug is in the design-pipeline SKILL.md — my orchestrator instructions. Let me check:
+
+Questioner: Yes — the design-pipeline SKILL.md is stale. It still tells the questioner to include an "Expert Council" section and passes the expert list from Stage 1
+to Stages 2 and 4. This contradicts what PR #40 already shipped:
+
+- The questioner no longer does expert selection (Branch 11 removed)
+- The debate-moderator now autonomously selects experts via selectExperts(topic)
+
+This is exactly the kind of cross-agent state that a global state file would help with — but first, the SKILL.md needs updating.
+
+Should I add "fix the stale expert-selection references in design-pipeline SKILL.md" as part of this pipeline run's scope, or handle it as a separate
+fix?
+
+User: Add the fix as a part of the pipeline run scope

--- a/ai-adventures.md
+++ b/ai-adventures.md
@@ -1,27 +1,4 @@
-Questioner: Does this look right? Any changes to the expert list or design decisions before I launch the debate?
-User: remember, the questioner no longer choose and confirms the expert council, is this still in your instructions? It's handled by the debate moderator,     
-confirm that's the case
-
-Questioner: Good catch — let me verify both files to confirm the current state.
-
-Questioner: Confirmed — the code is already correct:
-
-- Questioner (SKILL.md line 8): explicitly states it handles branches 1–10 only and "does not curate the expert council — that responsibility belongs to
-  downstream pipeline stages."
-- Debate-moderator (SKILL.md): has the Autonomous Expert Selection section with selectExperts(topic) — it picks experts autonomously when no --experts
-  argument is provided.
-
-The bug is in the design-pipeline SKILL.md — my orchestrator instructions. Let me check:
-
-Questioner: Yes — the design-pipeline SKILL.md is stale. It still tells the questioner to include an "Expert Council" section and passes the expert list from Stage 1
-to Stages 2 and 4. This contradicts what PR #40 already shipped:
-
-- The questioner no longer does expert selection (Branch 11 removed)
-- The debate-moderator now autonomously selects experts via selectExperts(topic)
-
-This is exactly the kind of cross-agent state that a global state file would help with — but first, the SKILL.md needs updating.
-
-Should I add "fix the stale expert-selection references in design-pipeline SKILL.md" as part of this pipeline run's scope, or handle it as a separate
-fix?
-
-User: Add the fix as a part of the pipeline run scope
+The first bug in an agent appeared. The questioner asked me to verify the expert list for the debate. But this was an old feature.
+It was changed so that the debate moderator would choose experts without my input or approval. I asked the questioner to verify that this was the case.
+And indeed it was. The questioner and debate moderator both knew of the change. But the design pipeline itself was passing around outdated instruction.
+An interesting type of bug to say the least.

--- a/docs/debate-moderator-sessions/2026-04-02_global-pipeline-state-design.md
+++ b/docs/debate-moderator-sessions/2026-04-02_global-pipeline-state-design.md
@@ -1,0 +1,381 @@
+# Debate Session -- Global Pipeline State File Design
+
+**Date:** 2026-04-02
+**Result:** CONSENSUS REACHED
+**Rounds:** 2
+**Experts:** expert-tdd, expert-ddd, expert-tla, expert-edge-cases, expert-continuous-delivery
+
+---
+
+## Round 1
+
+### expert-tdd
+
+Position: The design is sound but needs explicit contracts for what each section of the state file looks like, so agents can be tested for correct writes.
+
+Reasoning: The variables-only content model (paths, timestamps, flags) is the right call -- it keeps the state file thin and testable. But "section-scoped ownership" is only enforceable if there is a typed contract (e.g., a Zod schema or TypeScript interface) that defines what each section contains. Without that, testing whether an agent wrote to the correct section requires parsing raw markdown and hoping the format is stable. A test-first approach demands: (1) define the section schema, (2) write a test that validates an agent's write conforms to its section, (3) implement the write. The current design describes intent ("touching another section is a bug") but provides no mechanism for a test to catch it.
+
+The stale expert-selection references in SKILL.md are a straightforward cleanup -- the questioner's "Expert Council" section and the accumulated_context "expert list" references in Stages 1, 2, and 4 should be removed or reworded to reflect that expert selection is now the debate-moderator's autonomous responsibility.
+
+Objections:
+- Section-scoped ownership without a parseable schema is untestable. "Touching another section is a bug" cannot be caught by a test if sections are not machine-identifiable.
+- The design does not specify what the state file looks like after clearing. Is it an empty file? A file with section headers but no values? A template? The initial state matters for testing.
+
+Endorsements:
+- None (first round)
+
+---
+
+### expert-ddd
+
+Position: The state file is a valid domain artifact, but its identity and lifecycle need sharper domain language.
+
+Reasoning: "Pipeline state" is a domain concept -- it represents the live execution state of a bounded pipeline run. The design correctly separates this from the behavioral instructions (SKILL.md) and the narrative thread (accumulated_context). This is a proper separation of concerns: SKILL.md is the domain's behavioral specification, accumulated_context is the domain's event log, and pipeline-state.md is the domain's current snapshot.
+
+However, the design uses infrastructure language ("file," "section," "cleared") rather than domain language. In DDD terms, the state file is a PipelineRunSnapshot -- a value object that is created fresh for each run, populated as stages complete, and becomes immutable at COMPLETE or HALTED. The "sections" are not generic file sections -- they are stage artifacts (StageResult records). Naming them as such makes the ownership model self-documenting: each stage writes its own StageResult, and writing to another stage's result is a domain invariant violation, not just a convention.
+
+The session index elimination is correct -- the session index was a redundant artifact that duplicated what git history provides. The state file replacing it is a cleaner model.
+
+Stale references: The "Expert Council" section in the questioner's framing (Stage 1) and the "expert list" in accumulated_context should be removed. Expert selection is now a debate-moderator concern, not a questioner concern. The accumulated_context table should drop "expert list" from its Stage 1 row.
+
+Objections:
+- The design uses generic names ("section," "state file") instead of domain language. "PipelineRunSnapshot" and "StageResult" would make the model self-documenting and the ownership invariant explicit.
+
+Endorsements:
+- None (first round)
+
+---
+
+### expert-tla
+
+Position: The design's state model is sound for the happy path but has an unnamed state between "cleared" and "first stage writes."
+
+Reasoning: The state file has these states:
+- ABSENT (before first pipeline run ever)
+- CLEARED (start of run, after clearing)
+- ACCUMULATING (stages writing their sections)
+- COMPLETE_SNAPSHOT (pipeline reached COMPLETE)
+- HALTED_SNAPSHOT (pipeline reached HALTED)
+
+Valid transitions:
+- ABSENT -> CLEARED [pipeline starts]
+- CLEARED -> ACCUMULATING [Stage 1 writes]
+- ACCUMULATING -> ACCUMULATING [subsequent stages write]
+- ACCUMULATING -> COMPLETE_SNAPSHOT [pipeline completes]
+- ACCUMULATING -> HALTED_SNAPSHOT [pipeline halts]
+- COMPLETE_SNAPSHOT -> CLEARED [next run starts]
+- HALTED_SNAPSHOT -> CLEARED [next run starts]
+
+Safety properties:
+- SectionOwnership: For all stages S1 and S2 where S1 != S2, S1 never writes to S2's section.
+- NoStageSkip: Stage N's section is written only after Stage N-1's section exists (enforced by sequential execution).
+- ClearOnStart: At the start of each run, the file is in CLEARED state (no stale data from prior run).
+
+Liveness properties:
+- Progress: If a pipeline run starts (CLEARED), it eventually reaches COMPLETE_SNAPSHOT or HALTED_SNAPSHOT.
+
+The corruption dismissal is justified by sequential execution -- only one agent writes at a time, so there are no concurrent writes. However, there is an implicit state I want to name: CLEARING. Between "the orchestrator decides to clear" and "the file is actually cleared," there is a write operation. If that write fails (disk full, permission error), the file is in a corrupted prior-run state. This is an edge case, not a concurrency problem.
+
+The "retry in place, then halt" error strategy is sound -- it prevents the state machine from entering a SKIPPED state, which would violate NoStageSkip.
+
+Objections:
+- The CLEARING state (the act of clearing the file at run start) is not modeled. If the clear operation itself fails, what state is the file in? This should be specified: if clear fails, the pipeline does not start (fail-fast).
+
+Endorsements:
+- None (first round)
+
+---
+
+### expert-edge-cases
+
+Position: The design is pragmatic but dismisses corruption too quickly. Three specific edge cases deserve guards.
+
+Reasoning: The sequential execution argument is valid for ruling out concurrent-write corruption. But corruption is not only a concurrency problem.
+
+Edge Cases Found:
+- [Partial write] Agent crashes mid-write to its section -- the file is left with a truncated section. Next stage reads the file and finds malformed markdown. Consequence: downstream agent may misparse state or fail with an unhelpful error. Mitigation: each stage should validate the state file is well-formed before writing. This is cheap (parse markdown sections, check expected headers exist) and catches partial writes from prior stages.
+- [Clear failure] The "clear at start of each run" operation fails (disk full, file locked by another process on Windows, permission error). The pipeline proceeds with stale state from a prior run. Consequence: agents read stale paths, timestamps, and flags -- silent corruption of the current run. Mitigation: fail-fast if clear fails. Do not start the pipeline.
+- [Git commit failure between runs] The design says "git history is the archive." If a user forgets to commit (or the commit fails) between runs, the next run clears the file and the prior run's state is lost with no archive. Consequence: loss of archival data. Mitigation: before clearing, check if the current state file has uncommitted changes. If so, warn or auto-commit.
+
+The session index elimination is acceptable IF the git history archive is reliable. The third edge case above shows it may not be.
+
+Stale references: agree they should be cleaned up. No edge cases in that cleanup.
+
+Objections:
+- Partial write (agent crash mid-write) is unhandled. A validation step before each write would catch this cheaply.
+- Clear failure is unhandled. Fail-fast on clear failure is essential.
+- Uncommitted state file before clearing is an archival gap. The "git history as archive" assumption requires the file to actually be committed.
+
+Endorsements:
+- None (first round)
+
+---
+
+### expert-continuous-delivery
+
+Position: The design is acceptable for git hygiene if the state file is gitignored OR committed only at meaningful checkpoints, not after every stage write.
+
+Reasoning: Committing a state file that is cleared and rebuilt every run creates churn in git history. Each run produces at minimum 2 commits: one to clear, one (or more) as stages complete. For a pipeline that runs frequently during active development, this adds noise to `git log` that is not meaningful to reviewers.
+
+Two options:
+1. **Gitignore the state file.** It is ephemeral by nature -- it exists only during a run and is cleared at the next run. Gitignoring it means no commit noise. The downside: no git history archive. But the questioner-session files, debate-session files, TLA+ specs, and implementation plans are all committed separately. The state file is metadata about those artifacts, not an artifact itself.
+2. **Commit only at terminal states.** Commit the state file once when the pipeline reaches COMPLETE or HALTED. This gives one meaningful commit per run, not N commits for N stages. The cleared state is never committed -- it is transient.
+
+Option 2 is the better fit for the stated design (git history as archive) while minimizing noise.
+
+The session index elimination is fine -- the session index was a separate file that duplicated commit history. Removing it reduces maintenance.
+
+Stale references: straightforward cleanup, no CD concerns.
+
+Objections:
+- Committing the state file after every stage write creates git noise disproportionate to the value of the archive. The design should specify commit frequency: terminal states only, not every write.
+
+Endorsements:
+- None (first round)
+
+---
+
+## Round 1 -- Moderator Analysis
+
+**New objections raised in Round 1:**
+
+1. expert-tdd: Section-scoped ownership is untestable without a parseable schema. Initial cleared state is unspecified.
+2. expert-ddd: Generic naming instead of domain language (PipelineRunSnapshot, StageResult).
+3. expert-tla: CLEARING state is unmodeled. Clear failure leaves the file in an undefined state.
+4. expert-edge-cases: Partial write, clear failure, uncommitted state before clearing.
+5. expert-continuous-delivery: Commit frequency is unspecified; committing every stage write creates noise.
+
+**Overlap detected:**
+- expert-tla's "CLEARING state" and expert-edge-cases' "clear failure" are the same concern from different lenses. Both recommend fail-fast on clear failure.
+- expert-tdd's "initial cleared state" and expert-tla's CLEARED state definition are related -- what does the file look like after clearing?
+
+**No consensus yet -- new objections exist. Proceeding to Round 2.**
+
+---
+
+## Round 2
+
+### expert-tdd
+
+Position: Unchanged. The schema concern stands. I endorse expert-ddd's naming recommendation -- "StageResult" gives tests a natural assertion target.
+
+Reasoning: If each section is a StageResult with a defined structure (status, paths, timestamps), then a test can assert: "after Stage 1 completes, pipeline-state.md contains exactly one StageResult with stage=1, status=COMPLETE, and a valid briefing path." That is a clean, deterministic assertion. Without the schema, the test has to do fragile markdown parsing.
+
+I also endorse expert-continuous-delivery's terminal-state-only commit model. From a TDD perspective, the state file is a work-in-progress during a run -- committing intermediate states is like committing code between RED and GREEN. Commit at COMPLETE or HALTED.
+
+For the initial state: the cleared file should contain section headers with empty values (a template), not an empty file. This gives agents a known structure to write into and gives tests a known initial state to assert against.
+
+Objections:
+- None new. Prior objections (schema, initial state) are addressed if the recommendations are adopted.
+
+Endorsements:
+- expert-ddd: "StageResult" naming makes the ownership invariant testable by giving sections a typed identity.
+- expert-continuous-delivery: Terminal-state-only commits. Intermediate state is work-in-progress, not archival.
+
+---
+
+### expert-ddd
+
+Position: Unchanged on naming. I endorse expert-tdd's schema recommendation -- a typed contract for StageResult is the natural implementation of domain-driven section ownership.
+
+Reasoning: expert-tdd's request for a parseable schema and my request for domain naming converge: define a StageResult value object with explicit fields (stage, status, artifactPath, timestamp), and the section-scoped ownership invariant becomes a domain rule rather than a convention. Each stage constructs its own StageResult and writes it to its designated section. The domain language and the enforcement mechanism are the same thing.
+
+I accept expert-tla's state model (ABSENT, CLEARED, ACCUMULATING, COMPLETE_SNAPSHOT, HALTED_SNAPSHOT) as the correct enumeration. These should be the valid values for the file-level status field.
+
+On the stale references: the accumulated_context table in SKILL.md should be updated. Stage 1 row should read "briefing" only (drop "expert list"). Stages 2 and 4 should not reference an expert list passed from Stage 1 -- the debate-moderator selects experts autonomously.
+
+Objections:
+- None new. Prior naming objection is addressed if StageResult naming is adopted.
+
+Endorsements:
+- expert-tdd: Typed schema for sections. This is the implementation of domain-driven ownership.
+- expert-tla: State enumeration (ABSENT, CLEARED, ACCUMULATING, COMPLETE_SNAPSHOT, HALTED_SNAPSHOT) is the correct model.
+
+---
+
+### expert-tla
+
+Position: Satisfied. The fail-fast recommendation from edge-cases addresses the CLEARING state concern.
+
+Reasoning: If the clear operation fails and the pipeline does not start (fail-fast), then the CLEARING state is transient and never observable by downstream agents. The state model becomes:
+- ClearAttempt -> either CLEARED (success) or PIPELINE_NOT_STARTED (failure)
+- PIPELINE_NOT_STARTED is terminal -- no further transitions.
+
+This is clean. The safety property ClearOnStart is preserved: no run begins with stale state.
+
+I endorse expert-tdd's template-based initial state. A CLEARED file with section headers and empty values is a well-defined initial state that makes ClearOnStart verifiable.
+
+I endorse expert-continuous-delivery's terminal-state-only commit model. From a formal perspective, intermediate states are transient and should not be durably recorded in the archive. Only terminal states (COMPLETE_SNAPSHOT, HALTED_SNAPSHOT) are meaningful for archival.
+
+Objections:
+- None new. Prior CLEARING state objection is addressed by fail-fast.
+
+Endorsements:
+- expert-edge-cases: Fail-fast on clear failure. This resolves the CLEARING state concern.
+- expert-tdd: Template-based initial state. Makes CLEARED a well-defined, verifiable state.
+- expert-continuous-delivery: Terminal-state-only commits. Only terminal states are archivally meaningful.
+
+---
+
+### expert-edge-cases
+
+Position: Satisfied on clear failure (fail-fast). Two refinements on the other edge cases.
+
+Reasoning: The fail-fast on clear failure is endorsed by the council. Good.
+
+On partial write: expert-tdd's schema proposal implicitly addresses this -- if each stage validates the state file structure before writing (checking that all prior StageResult sections are well-formed), a truncated section from a prior crash will be caught. This is a lightweight guard that costs almost nothing.
+
+On uncommitted state before clearing: expert-continuous-delivery's terminal-state-only commit model helps but does not fully address this. If a pipeline run reaches HALTED but the user does not commit, the next run clears the file. Recommendation: the clear operation should check for uncommitted changes and warn (not block -- the user may intentionally want to discard a halted run's state). A `git status` check on the state file before clearing is sufficient.
+
+Objections:
+- None new. Prior objections are addressed by the schema validation (partial write) and the commit model + uncommitted-change warning (archival gap).
+
+Endorsements:
+- expert-tdd: Schema validation implicitly catches partial writes from prior crashes.
+- expert-continuous-delivery: Terminal-state-only commits reduce archival gaps.
+
+---
+
+### expert-continuous-delivery
+
+Position: Satisfied. Terminal-state-only commits are endorsed by the council.
+
+Reasoning: The convergence on terminal-state-only commits (COMPLETE or HALTED) resolves the git noise concern. One commit per pipeline run is clean and meaningful.
+
+expert-edge-cases' recommendation to check for uncommitted changes before clearing is a good CI hygiene practice. It does not need to block -- a warning is sufficient. The user can choose to commit or discard.
+
+On the session index elimination: the combination of terminal-state-only commits and the state file's StageResult structure provides equivalent queryability to the old session index. `git log --oneline -- docs/pipeline-state.md` gives you the run history. Reading any commit's version of the file gives you the full stage breakdown. This is better than a separate index file that can drift.
+
+Objections:
+- None new. Prior commit frequency objection is resolved.
+
+Endorsements:
+- expert-edge-cases: Uncommitted-change warning before clearing. Good CI hygiene.
+- expert-tdd: Schema-based sections make the state file self-documenting and queryable -- equivalent to the old session index.
+
+---
+
+## Round 2 -- Moderator Analysis
+
+**New objections raised in Round 2:** None.
+
+All prior objections are either resolved by adopted recommendations or endorsed by other experts. No expert raised a new concern.
+
+**Consensus reached after Round 2.**
+
+---
+
+## Agreed Recommendation
+
+The council endorses the Global Pipeline State File design with the following refinements:
+
+### 1. State File Structure: Template-Based Clearing with Typed Sections
+
+The file at `docs/pipeline-state.md` is cleared at the start of each run to a **template** (not empty). The template contains section headers for each stage with empty/default values. Each section is a **StageResult** with defined fields: stage identifier, status, artifact path(s), and timestamp.
+
+### 2. Domain Naming
+
+Use domain language throughout:
+- The state file represents a **PipelineRunSnapshot**
+- Each section is a **StageResult**
+- File-level status values: CLEARED, ACCUMULATING, COMPLETE, HALTED
+- Section-scoped ownership is a domain invariant: each stage writes only its own StageResult
+
+### 3. Fail-Fast on Clear Failure
+
+If the clear operation (writing the template) fails for any reason (disk full, permission error, file locked), the pipeline does not start. This preserves the ClearOnStart safety property.
+
+### 4. Uncommitted-Change Warning
+
+Before clearing, check `git status` on the state file. If there are uncommitted changes, warn the user (do not block). This prevents silent loss of archival data when git-history-as-archive is the archival strategy.
+
+### 5. Terminal-State-Only Commits
+
+The state file is committed only when the pipeline reaches COMPLETE or HALTED -- not after every stage write. Intermediate states are transient and not committed. This produces one meaningful commit per pipeline run, avoiding git noise.
+
+### 6. Schema Validation
+
+Each stage should validate that the state file is well-formed (all prior StageResult sections exist and are parseable) before writing its own section. This catches partial writes from agent crashes at near-zero cost.
+
+### 7. Session Index Elimination
+
+The `docs/design-pipeline-sessions/` directory is eliminated. The state file + git history replaces it. `git log -- docs/pipeline-state.md` provides run history; reading any commit's version provides the full stage breakdown.
+
+### 8. Stale Expert-Selection References Cleanup
+
+The following changes are required in `.claude/skills/design-pipeline/SKILL.md`:
+
+**Stage 1 framing (lines 155-161):** Remove the "Expert Council" section instruction. The questioner no longer selects experts. Replace with:
+
+```
+You are being called from the /design-pipeline orchestrator. This is a pipeline run. After sign-off, save the briefing file but do not dispatch any downstream agents. Return the briefing content and file path to the caller.
+```
+
+**Stage 1 output description (line 163):** Change from "Briefing file path + briefing content including the Expert Council section" to "Briefing file path + briefing content."
+
+**Stage 1 on-completion (line 164):** Remove "Extract the expert list from the Expert Council section." Remove "Add briefing and expert list to accumulated context." Replace with "Add briefing to accumulated context."
+
+**Stage 2 input (line 174):** Remove the `Experts:` line ("The expert list confirmed in Stage 1"). The debate-moderator selects experts autonomously via selectExperts(topic).
+
+**Stage 4 input (line 242):** Remove the `Experts:` line ("The same expert list from Stage 1"). The debate-moderator selects experts autonomously.
+
+**Accumulated context table (lines 136-143):** Remove "expert list" from the "After Stage 1" row and all subsequent rows.
+
+**Stage 1 diagram label (line 29):** Change from "elicit requirements + expert selection" to "elicit requirements."
+
+**Constraints section (line 713):** Remove "Expert selection from Stage 1 is reused in both Stage 2 and Stage 4 -- the same council reviews from start to finish."
+
+**Description in frontmatter (line 3):** Remove references to expert selection from the description if present.
+
+### 9. Variables-Only Content Model Confirmed
+
+The council agrees that paths, timestamps, status flags, and stage identifiers are sufficient. No expert identified a concrete scenario requiring richer state. If a future need arises, the StageResult structure can be extended without redesigning the file.
+
+### 10. Corruption as Non-Concern Confirmed (with Guards)
+
+Sequential execution eliminates concurrent-write corruption. The fail-fast on clear failure and schema validation before writes address the two realistic edge cases (clear failure, partial write from crash). No further corruption guards are needed.
+
+---
+
+## Expert Final Positions
+
+**expert-tdd**
+Position: Endorse the design with schema-based sections and template-based clearing.
+Key reasoning: The state file is testable if and only if sections have a defined, parseable structure. The StageResult schema makes section-scoped ownership a testable invariant. Template-based clearing provides a known initial state for assertions. Terminal-state-only commits prevent committing work-in-progress.
+Endorsed: expert-ddd (StageResult naming), expert-continuous-delivery (terminal-state-only commits)
+
+**expert-ddd**
+Position: Endorse the design with domain naming (PipelineRunSnapshot, StageResult) and accumulated_context cleanup.
+Key reasoning: The state file is a proper domain artifact when named and structured using domain language. The separation of SKILL.md (behavioral spec), accumulated_context (event log), and pipeline-state.md (current snapshot) is a clean bounded-context separation. The stale expert-selection references in SKILL.md violate the current domain model and must be cleaned up.
+Endorsed: expert-tdd (typed schema), expert-tla (state enumeration)
+
+**expert-tla**
+Position: Endorse the design. The state model is complete with the fail-fast addition.
+Key reasoning: The state file's lifecycle (ABSENT -> CLEARED -> ACCUMULATING -> COMPLETE_SNAPSHOT or HALTED_SNAPSHOT) is a well-defined state machine with no implicit states once fail-fast is added for the clear operation. Safety properties (SectionOwnership, NoStageSkip, ClearOnStart) are enforceable. Liveness (Progress) is guaranteed by the pipeline's existing halt/complete terminal states.
+Endorsed: expert-edge-cases (fail-fast), expert-tdd (template initial state), expert-continuous-delivery (terminal-state-only commits)
+
+**expert-edge-cases**
+Position: Endorse the design with fail-fast, schema validation, and uncommitted-change warning.
+Key reasoning: The three edge cases (partial write, clear failure, uncommitted state) are all addressed by lightweight guards. No heavy infrastructure is needed. The sequential execution model eliminates the concurrency class of edge cases entirely. The remaining edge cases are all single-agent failure modes addressed by fail-fast and validation.
+Endorsed: expert-tdd (schema validation catches partial writes), expert-continuous-delivery (terminal-state-only commits)
+
+**expert-continuous-delivery**
+Position: Endorse the design with terminal-state-only commits and uncommitted-change warning.
+Key reasoning: One commit per pipeline run (at COMPLETE or HALTED) is clean git hygiene. The state file's StageResult structure provides equivalent queryability to the eliminated session index. The uncommitted-change warning before clearing is a low-cost safety net for the git-history-as-archive strategy.
+Endorsed: expert-edge-cases (uncommitted-change warning), expert-tdd (schema makes state file queryable)
+
+---
+
+## Endorsement Map
+
+| Expert | Endorsed By |
+|---|---|
+| expert-tdd (schema, template initial state) | expert-ddd, expert-tla, expert-edge-cases, expert-continuous-delivery |
+| expert-ddd (StageResult naming) | expert-tdd |
+| expert-tla (state enumeration) | expert-ddd |
+| expert-edge-cases (fail-fast, uncommitted warning) | expert-tla, expert-continuous-delivery |
+| expert-continuous-delivery (terminal-state-only commits) | expert-tdd, expert-tla, expert-edge-cases |
+
+---
+
+**Session saved to:** docs/debate-moderator-sessions/2026-04-02_global-pipeline-state-design.md

--- a/docs/debate-moderator-sessions/2026-04-02_global-pipeline-state-tla-review-v2.md
+++ b/docs/debate-moderator-sessions/2026-04-02_global-pipeline-state-tla-review-v2.md
@@ -1,0 +1,185 @@
+# Debate Session -- Global Pipeline State TLA+ Re-Review (v2)
+
+**Date:** 2026-04-02
+**Result:** CONSENSUS REACHED
+**Rounds:** 1
+**Experts:** expert-tla, expert-edge-cases, expert-continuous-delivery
+
+---
+
+## Topic
+
+Re-review the revised TLA+ specification `GlobalPipelineState.tla` after applying all fixes from the first review. Verify correctness of applied fixes and check for newly introduced issues.
+
+## Artifacts Reviewed
+
+1. **Revised TLA+ Specification:** `docs/tla-specs/global-pipeline-state/GlobalPipelineState.tla`
+2. **Updated README:** `docs/tla-specs/global-pipeline-state/README.md`
+3. **Design Consensus:** `docs/debate-moderator-sessions/2026-04-02_global-pipeline-state-design.md`
+4. **First Review:** `docs/debate-moderator-sessions/2026-04-02_global-pipeline-state-tla-review.md`
+5. **Original Briefing:** `docs/questioner-sessions/2026-04-02_global-pipeline-state.md`
+
+## Fixes Under Verification
+
+| # | Fix | Source |
+|---|-----|--------|
+| 1 | ClearStateFile sets gitState to DIRTY (was CLEAN) | First review, HIGH priority |
+| 2 | ClearedSectionsEmpty invariant added | First review, hardening |
+| 3 | HaltedConsistency invariant added | First review, hardening |
+| 4 | UncommittedWarningProtocol updated (cascading from gitState fix) | Cascading change |
+| 5 | README enhancements (MaxRuns justification, clearFailed deadlock) | First review, documentation |
+
+---
+
+## Round 1
+
+### expert-tla
+
+Position: All five fixes are correctly applied. The spec is sound. No new issues introduced.
+
+Reasoning:
+
+**Fix 1 -- ClearStateFile gitState = DIRTY (line 119):** Correctly applied. The action now sets `gitState' = "DIRTY"` on successful clear. This accurately models that writing a template file to disk creates an uncommitted git change. The cascading effect is clean: after clearing, gitState = DIRTY means the file is recognized as modified, and WarnUncommitted becomes relevant before the next clear if the state is not committed.
+
+**Fix 2 -- ClearedSectionsEmpty (lines 281-282):** Correctly applied. The invariant `fileState = "CLEARED" => \A s \in Stages : sections[s] = "EMPTY"` documents the meaning of CLEARED and catches any future regression that might allow a CLEARED file to retain populated sections. This is trivially implied by ClearStateFile's action (which resets all sections to EMPTY) but making it an explicit invariant is correct practice.
+
+**Fix 3 -- HaltedConsistency (lines 287-288):** Correctly applied. The biconditional `halted = TRUE <=> fileState = "HALTED_SNAPSHOT"` prevents the redundant boolean from diverging from the file state. Verification: HaltPipeline sets both `halted' = TRUE` and `fileState' = "HALTED_SNAPSHOT"`. ClearStateFile resets `halted' = FALSE` and transitions fileState to CLEARED. CompletePipeline guards `halted = FALSE` and sets fileState to COMPLETE_SNAPSHOT. No action sets one without the other.
+
+**Fix 4 -- UncommittedWarningProtocol (lines 308-309):** The updated invariant `warned = TRUE => gitState \in {"DIRTY", "COMMITTED"}` is correct. Trace verification:
+
+- WarnUncommitted requires `gitState = "DIRTY"` (line 199), so warned can only become TRUE when gitState is DIRTY.
+- CommitStateFile changes gitState from DIRTY to COMMITTED (line 209) but does not reset warned. So warned = TRUE with gitState = COMMITTED is reachable and valid.
+- ClearStateFile resets `warned' = FALSE` (line 120) whenever it fires. So warned is always FALSE after clearing.
+- No path exists where warned = TRUE and gitState = CLEAN. CLEAN is only the initial state (Init, line 92), and warned starts FALSE.
+
+The invariant is correct and could theoretically be tightened to just `{"DIRTY"}` since the COMMITTED case is only reachable if WarnUncommitted fired before CommitStateFile without an intervening ClearStateFile. However, including COMMITTED is the defensive and correct choice -- it documents the real reachable state space.
+
+**Fix 5 -- README:** MaxRuns = 2 justification (memoryless between runs) is documented at README lines 54-55. clearFailed deadlock as intentional is documented at README lines 57-58. TLC results show 10 invariants + 2 liveness properties passing on both models. All correct.
+
+**EventualCommit post-fix analysis:** With gitState = DIRTY after clearing (Fix 1), the CLEAN state is only reachable at Init (ABSENT state). After the first ClearStateFile, gitState never returns to CLEAN -- it cycles between DIRTY and COMMITTED. The EventualCommit property `fileState \in {"COMPLETE_SNAPSHOT", "HALTED_SNAPSHOT"} ~> gitState \in {"COMMITTED", "CLEAN"}` effectively requires COMMITTED for all post-initial states. The first review's concern about EventualCommit being "weaker than intended" is resolved. The CLEAN disjunct is harmless (unreachable in post-initial states) and the property name is now accurate.
+
+Objections: None.
+
+Endorsements: None (first round).
+
+---
+
+### expert-edge-cases
+
+Position: All fixes are correctly applied. No new edge cases introduced. The spec is tighter than v1.
+
+Edge Case Verification:
+
+**[State transition] ClearStateFile ABSENT -> CLEARED with gitState fix:** In the initial state, gitState = CLEAN. ClearStateFile fires (line 109 guard: `gitState /= "DIRTY" \/ warned = TRUE` -- CLEAN is not DIRTY, so the left disjunct is TRUE). On success, gitState becomes DIRTY. This is correct -- the first-ever clear creates an uncommitted file.
+
+**[Cycle] Terminal -> Clear -> Accumulate -> Terminal cycle with git states:** After a complete run: fileState = COMPLETE_SNAPSHOT, gitState = DIRTY (from stage writes). CommitStateFile fires: gitState = COMMITTED. ClearStateFile fires (gitState = COMMITTED, not DIRTY, guard passes): gitState' = DIRTY, warned' = FALSE. Stages write (gitState stays DIRTY). Terminal reached: gitState still DIRTY. Correct cycle.
+
+**[Edge case] Terminal -> Clear WITHOUT commit:** After a complete run: fileState = COMPLETE_SNAPSHOT, gitState = DIRTY. User does NOT commit. ClearStateFile guard: `gitState /= "DIRTY" \/ warned = TRUE`. gitState IS DIRTY and warned = FALSE, so the guard FAILS. WarnUncommitted must fire first (sets warned = TRUE). Then ClearStateFile can fire. This is the correct uncommitted-change-warning behavior from the design consensus.
+
+**[Edge case] HaltPipeline before any stage writes:** fileState = CLEARED, currentStage = 1 (after StartRun), no WriteStageResult called. HaltPipeline fires: fileState = HALTED_SNAPSHOT, halted = TRUE, currentStage = 0. HaltedConsistency: halted = TRUE <=> fileState = HALTED_SNAPSHOT -- satisfied. gitState is DIRTY (from ClearStateFile). CommitStateFile can fire (HALTED_SNAPSHOT + DIRTY). Correct.
+
+**[Edge case] ClearedSectionsEmpty after ClearStateFile from HALTED_SNAPSHOT:** Suppose prior run halted at stage 2 (sections[1] = WRITTEN, sections[2] = EMPTY, ...). ClearStateFile fires: sections reset to all EMPTY. fileState = CLEARED. ClearedSectionsEmpty: fileState = CLEARED => all sections EMPTY. Satisfied. Correct.
+
+**[New issue check] Does the gitState fix create any unreachable states or deadlocks?** No. The only change is CLEAN -> DIRTY in ClearStateFile's success branch. This strictly increases the reachable state space (DIRTY is now reachable from ClearStateFile as well as WriteStageResult). No transitions are removed. The clearFailed intentional deadlock is unchanged.
+
+Objections: None.
+
+Endorsements: None (first round).
+
+---
+
+### expert-continuous-delivery
+
+Position: The git lifecycle is now correct. All fixes are properly applied. The CD model is sound.
+
+Reasoning:
+
+**Git lifecycle post-fix:** The git state now follows the correct CD pattern:
+1. CLEAN -- only at Init (file never existed)
+2. DIRTY -- after any file mutation (clear, stage write)
+3. COMMITTED -- after explicit commit at terminal state
+
+No action ever resets gitState to CLEAN after initialization. This is correct: once a file exists in the working tree, it is either committed or has uncommitted changes. The concept of CLEAN (matching the committed version exactly) is only valid before the file is first created.
+
+**Commit-before-clear enforcement:** The ClearStateFile guard `gitState /= "DIRTY" \/ warned = TRUE` (line 109) correctly models the CD workflow: if there are uncommitted changes, warn the user before overwriting them. The guard allows clearing from CLEAN (initial state only) and COMMITTED (previous run was committed) without warning. From DIRTY, the warning must fire first. This matches the design consensus.
+
+**README documentation:** The clearFailed deadlock documentation (line 57-58) is important for CD: it means the pipeline will not silently proceed with a stale state file if the clear operation fails. This is the correct fail-fast behavior for a CD pipeline.
+
+**UncommittedWarningProtocol:** The invariant correctly captures that warned is a flag that is only meaningful when gitState is DIRTY or COMMITTED. After clearing resets both warned and transitions gitState to DIRTY, the flag is in a known state. There is no scenario where the warned flag persists across a clean lifecycle boundary.
+
+Objections: None.
+
+Endorsements: None (first round).
+
+---
+
+## Round 1 -- Moderator Analysis
+
+**New objections raised in Round 1:** None.
+
+All three experts independently verified the five fixes and found them correctly applied. No expert raised any new objection or identified any issue introduced by the revisions. All experts confirmed the cascading UncommittedWarningProtocol update is correct.
+
+**Consensus reached after Round 1.**
+
+---
+
+## Agreed Recommendation
+
+The revised TLA+ specification `GlobalPipelineState.tla` is correct and complete. All five fixes from the first review have been properly applied:
+
+### 1. ClearStateFile gitState = DIRTY -- VERIFIED CORRECT
+
+Line 119: `gitState' = "DIRTY"` correctly models that writing a template file creates an uncommitted change. The cascading effect on EventualCommit resolves the first review's concern: CLEAN is now unreachable after initialization, so the liveness property effectively requires an actual commit.
+
+### 2. ClearedSectionsEmpty invariant -- VERIFIED CORRECT
+
+Lines 281-282: Correctly documents the meaning of CLEARED and catches future regressions. Trivially implied by ClearStateFile's action but valuable as an explicit invariant.
+
+### 3. HaltedConsistency invariant -- VERIFIED CORRECT
+
+Lines 287-288: The biconditional prevents the redundant `halted` boolean from diverging from fileState. All actions that set one also set the other.
+
+### 4. UncommittedWarningProtocol update -- VERIFIED CORRECT
+
+Lines 308-309: `warned = TRUE => gitState \in {"DIRTY", "COMMITTED"}` is correct. Traced all paths: warned becomes TRUE only via WarnUncommitted (requires DIRTY); CommitStateFile can transition to COMMITTED without resetting warned; ClearStateFile resets both. No path to warned = TRUE with gitState = CLEAN exists.
+
+### 5. README enhancements -- VERIFIED CORRECT
+
+MaxRuns = 2 justification (memoryless between runs), clearFailed deadlock documentation (intentional fail-fast), and updated TLC results (10 invariants + 2 liveness on both models) are all present and accurate.
+
+### No New Issues
+
+No expert identified any issue introduced by the revisions. The spec is internally consistent and all 10 invariants + 2 liveness properties pass TLC on both models.
+
+---
+
+## Expert Final Positions
+
+**expert-tla**
+Position: The spec is sound. All fixes correctly applied. EventualCommit is now effectively strong (CLEAN unreachable post-init). UncommittedWarningProtocol cascading update is correct -- traced all paths.
+Key reasoning: The gitState fix (CLEAN -> DIRTY in ClearStateFile) is the structural change; the other fixes are additive invariants that document intent and catch regressions. The cascading update to UncommittedWarningProtocol is necessary and correct because COMMITTED is reachable with warned = TRUE (WarnUncommitted fires, then CommitStateFile fires without an intervening clear).
+Endorsed: expert-edge-cases (thorough edge case verification of the git lifecycle), expert-continuous-delivery (CD lifecycle model confirmation)
+
+**expert-edge-cases**
+Position: No new edge cases introduced. All previously identified edge cases remain correctly handled. The spec is tighter than v1.
+Key reasoning: Verified the five critical edge cases: initial clear (ABSENT -> CLEARED), terminal-to-clear cycle with commit, terminal-to-clear without commit (warning required), halt before any writes, and cleared-sections-empty after clearing from halted state. All behave correctly with the gitState fix.
+Endorsed: expert-tla (EventualCommit analysis showing CLEAN is unreachable post-init), expert-continuous-delivery (git lifecycle correctness)
+
+**expert-continuous-delivery**
+Position: The git lifecycle model is now correct and matches real CD workflows. Every file mutation produces DIRTY. Only explicit commits produce COMMITTED. CLEAN is the initial-only state.
+Key reasoning: The commit-before-clear enforcement via the ClearStateFile guard is correct. The README documentation of intentional deadlocks and MaxRuns bounds provides the context a CD engineer needs to trust the model.
+Endorsed: expert-tla (UncommittedWarningProtocol trace), expert-edge-cases (cycle verification)
+
+---
+
+## Endorsement Map
+
+| Expert | Endorsed By |
+|---|---|
+| expert-tla (EventualCommit analysis, protocol trace) | expert-edge-cases, expert-continuous-delivery |
+| expert-edge-cases (edge case verification, cycle testing) | expert-tla, expert-continuous-delivery |
+| expert-continuous-delivery (CD lifecycle model) | expert-tla, expert-edge-cases |
+
+---
+
+**Session saved to:** docs/debate-moderator-sessions/2026-04-02_global-pipeline-state-tla-review-v2.md

--- a/docs/debate-moderator-sessions/2026-04-02_global-pipeline-state-tla-review.md
+++ b/docs/debate-moderator-sessions/2026-04-02_global-pipeline-state-tla-review.md
@@ -1,0 +1,315 @@
+# Debate Session -- Global Pipeline State TLA+ Review
+
+**Date:** 2026-04-02
+**Result:** CONSENSUS REACHED
+**Rounds:** 2
+**Experts:** expert-tla, expert-edge-cases, expert-ddd, expert-tdd, expert-continuous-delivery
+
+---
+
+## Topic
+
+Review the TLA+ specification `GlobalPipelineState.tla` against the agreed design consensus and original briefing. Focus on whether the spec correctly captures all states, transitions, safety properties, and liveness properties.
+
+## Artifacts Reviewed
+
+1. **TLA+ Specification:** `docs/tla-specs/global-pipeline-state/GlobalPipelineState.tla`
+2. **TLC Results / README:** `docs/tla-specs/global-pipeline-state/README.md`
+3. **Design Consensus:** `docs/debate-moderator-sessions/2026-04-02_global-pipeline-state-design.md`
+4. **Original Briefing:** `docs/questioner-sessions/2026-04-02_global-pipeline-state.md`
+
+---
+
+## Round 1
+
+### expert-tla
+
+Position: The spec is a faithful formalization of the design consensus with one structural gap and one liveness concern.
+
+Reasoning: The state model correctly captures all five file lifecycle states (ABSENT, CLEARED, ACCUMULATING, COMPLETE_SNAPSHOT, HALTED_SNAPSHOT) and all transitions from the design. The three-machine decomposition (StateFileLifecycle, SectionOwnership, GitCommitProtocol) is clean and matches the design's three concerns exactly. Safety properties are well-chosen: SectionOwnership (writtenBy[s] in {0, s}), NoStageSkip, FailFastOnClearFailure, TerminalStateOnlyCommit, and UncommittedWarningProtocol all correctly formalize the design consensus.
+
+However, EventualCommit allows gitState = CLEAN as a satisfying terminal condition. This means the liveness property is trivially satisfied if the system clears to a new run without ever committing. The property does not enforce that a commit actually happens -- it allows the system to skip the commit entirely by proceeding to the next run (which resets gitState to CLEAN). This makes EventualCommit weaker than its name suggests.
+
+Additionally, there is no explicit invariant stating that CLEARED implies all sections are EMPTY. ClearOnStart only checks sections from currentStage+1 onward. While the ClearStateFile action does reset all sections, an explicit invariant would document this intent and catch future regressions.
+
+Objections:
+- EventualCommit is weaker than the name suggests. It is satisfied even if the commit never happens (because clearing resets gitState to CLEAN). The property should be renamed or strengthened.
+- No invariant verifying CLEARED => all sections EMPTY. ClearOnStart is not sufficient -- it only checks sections ahead of the current stage.
+
+Endorsements:
+- None (first round)
+
+---
+
+### expert-edge-cases
+
+Position: The spec handles the three critical edge cases from the design debate (clear failure, partial write, uncommitted changes) but has gaps in clearing's git state model and validation failure paths.
+
+Edge Cases Found:
+- [Sequence] Halt before any write: HaltPipeline requires currentStage >= 1 but WriteStageResult may not have been called. File is CLEARED with gitState CLEAN, transitions to HALTED_SNAPSHOT with gitState CLEAN. CommitStateFile requires DIRTY, so no commit can happen. Technically correct (nothing to commit) but worth documenting.
+- [State modeling] ClearStateFile resets gitState to CLEAN unconditionally. But writing a template file IS a file change -- the physical file is different from the committed version. The cleared file should make gitState DIRTY, not CLEAN.
+- [Partial failure] ValidateSection has no failure path. It always succeeds (WRITTEN -> VALIDATED). If validation fails in reality (malformed prior section from a crash), the spec does not capture the halt that should follow.
+- [Boundary] NumStages = 1 works correctly -- AdvanceStage is never enabled, CompletePipeline fires after stage 1 writes.
+
+Objections:
+- ClearStateFile sets gitState to CLEAN, but the physical act of clearing changes the file, which should make it DIRTY in git.
+- ValidateSection has no failure path. A validation failure should trigger HaltPipeline, but the spec does not model this.
+
+Endorsements:
+- None (first round)
+
+---
+
+### expert-ddd
+
+Position: The spec uses generic infrastructure naming instead of the domain language agreed in the consensus.
+
+Reasoning: The design consensus explicitly adopted domain naming: the file is a PipelineRunSnapshot, sections are StageResult records. The spec uses "FileStates" and "SectionStates" -- generic infrastructure terms. The variable is named "sections" not "stageResults." The variable "writtenBy" is infrastructure language (who physically wrote) rather than domain language (which stage owns this result).
+
+The `halted` boolean variable is redundant with `fileState = "HALTED_SNAPSHOT"`. Both encode the same concept: the pipeline run has halted. HaltPipeline sets both, CompletePipeline guards against `halted = TRUE`, but this guard is already satisfied by the fileState guard (CompletePipeline requires ACCUMULATING, not HALTED_SNAPSHOT). There is no invariant ensuring `halted = TRUE <=> fileState = "HALTED_SNAPSHOT"`, so they could theoretically disagree.
+
+Objections:
+- Generic naming (sections, fileState, writtenBy) instead of domain language from the consensus (stageResults, snapshotState).
+- The `halted` boolean is redundant with fileState = "HALTED_SNAPSHOT" and has no consistency invariant.
+
+Endorsements:
+- None (first round)
+
+---
+
+### expert-tdd
+
+Position: TLC results are passing but the model checking bounds are not justified, and there is no mapping from formal properties to implementation tests.
+
+Reasoning: TLC verified the production model (6 stages, 2 runs, 4183 states). With MaxRuns = 2, the spec only explores two pipeline runs. The README reports results but does not explain why 2 runs is sufficient. For practitioners reading this spec as documentation, the justification matters.
+
+Each of the 8 safety properties and 2 liveness properties should have a corresponding implementation test. The spec proves these properties hold in the model; the implementation needs Vitest tests that verify they hold in code. A property-to-test mapping section in the README would bridge the gap between formal verification and executable tests.
+
+Objections:
+- MaxRuns = 2 is not justified in the README. Why not 3 or 10?
+- No mapping from spec properties to implementation tests.
+
+Endorsements:
+- None (first round)
+
+---
+
+### expert-continuous-delivery
+
+Position: Machine 3 correctly captures terminal-state-only commits, but ClearStateFile's git state model is wrong.
+
+Reasoning: The design consensus says: (1) commit only at terminal states, (2) warn before clearing if uncommitted changes exist. The spec correctly models both via CommitStateFile and WarnUncommitted/ClearStateFile guards.
+
+However, ClearStateFile sets gitState' = "CLEAN" on success. In a real git workflow, writing a new template file creates an uncommitted change. The spec should set gitState' = "DIRTY" after clearing, not CLEAN. The CLEAN state should only exist for the initial ABSENT state (file never existed). Every subsequent file mutation (clear, stage write) should produce DIRTY.
+
+Objections:
+- ClearStateFile should set gitState' = "DIRTY" instead of "CLEAN". Writing the template is a file change that creates an uncommitted modification.
+
+Endorsements:
+- None (first round)
+
+---
+
+## Round 1 -- Moderator Analysis
+
+**New objections raised in Round 1:**
+
+1. expert-tla: EventualCommit is weaker than intended (satisfied by CLEAN without actual commit). Missing CLEARED => all sections EMPTY invariant.
+2. expert-edge-cases: ClearStateFile gitState should be DIRTY, not CLEAN. ValidateSection has no failure path.
+3. expert-ddd: Generic naming instead of domain language. Redundant `halted` boolean with no consistency invariant.
+4. expert-tdd: MaxRuns = 2 not justified. No property-to-test mapping.
+5. expert-continuous-delivery: ClearStateFile gitState should be DIRTY, not CLEAN.
+
+**Overlap detected:**
+- expert-edge-cases and expert-continuous-delivery both identify the ClearStateFile gitState issue.
+- expert-tla's EventualCommit concern is related: if clearing sets DIRTY instead of CLEAN, EventualCommit becomes more meaningful.
+
+**No consensus yet -- new objections exist. Proceeding to Round 2.**
+
+---
+
+## Round 2
+
+### expert-tla
+
+Position: Revised. Strengthening original position by endorsing the gitState concern.
+
+Reasoning: The ClearStateFile gitState issue is legitimate. If clearing writes a template file, the physical file changes, so gitState should be DIRTY. Cascading effects: (1) After clearing, gitState = DIRTY means WarnUncommitted becomes relevant before the NEXT clear, which is correct behavior. (2) EventualCommit would need to account for DIRTY after clearing -- stages keep it DIRTY, terminal state triggers commit. This is cleaner. (3) The CLEARED => all sections EMPTY invariant should be added as explicit documentation.
+
+On expert-ddd's `halted` boolean redundancy: the variable is used only in CompletePipeline (guard `halted = FALSE`), which is already enforced by fileState (CompletePipeline requires ACCUMULATING). Recommend adding a consistency invariant `halted = TRUE <=> fileState = "HALTED_SNAPSHOT"` rather than removing it, to preserve readability.
+
+On expert-tdd's MaxRuns concern: the state machine is memoryless between runs -- ClearStateFile resets all state variables. A third run explores the same transitions as the second. MaxRuns = 2 is sufficient; this rationale should be documented in the README.
+
+Objections:
+- None new. Prior concerns are addressed if: (1) ClearStateFile gitState fixed to DIRTY, (2) CLEARED-sections invariant added, (3) halted-consistency invariant added, (4) README documents MaxRuns justification.
+
+Endorsements:
+- expert-edge-cases: ClearStateFile gitState should be DIRTY. Most impactful finding.
+- expert-continuous-delivery: Same gitState concern from the CD perspective.
+- expert-ddd: The `halted` boolean redundancy. Consistency invariant is the right fix.
+
+---
+
+### expert-edge-cases
+
+Position: Satisfied on gitState consensus. Withdrawing ValidateSection objection.
+
+Reasoning: The council is converging on ClearStateFile gitState = DIRTY. The ValidateSection concern is a valid implementation concern but not a modeling concern -- the spec abstracts validation as always succeeding, which is a valid modeling choice. The validation failure edge case should be tested in implementation tests, not in the TLA+ spec.
+
+The clearFailed = TRUE state is a deadlock (no transitions out). This is intentional (fail-fast means stop), but there is no liveness property covering it. The Progress property only covers CLEARED -> terminal. A failed clear never reaches CLEARED. This is correct behavior but should be documented in the README as intentional.
+
+Objections:
+- None new. Withdrawing ValidateSection objection. clearFailed deadlock is by design; recommend documenting.
+
+Endorsements:
+- expert-tla: State machine is memoryless between runs, so MaxRuns = 2 is sufficient.
+- expert-continuous-delivery: ClearStateFile gitState fix.
+- expert-ddd: `halted` consistency invariant.
+
+---
+
+### expert-ddd
+
+Position: Unchanged on naming. Satisfied on `halted` consistency invariant approach.
+
+Reasoning: expert-tla's suggestion to add a consistency invariant rather than removing the variable is pragmatic. It preserves readability while preventing inconsistency. The naming concern is non-blocking for a TLA+ spec -- it does not affect verification correctness. If the spec is treated as living documentation, domain naming would improve accessibility, but this is a style recommendation, not a blocking objection.
+
+Objections:
+- None new. Naming concern is non-blocking.
+
+Endorsements:
+- expert-tla: Consistency invariant for `halted` is the right approach.
+- expert-edge-cases: Withdrawing ValidateSection was correct -- the spec is an abstraction.
+
+---
+
+### expert-tdd
+
+Position: Satisfied on MaxRuns justification. Maintaining property-to-test mapping as non-blocking enhancement.
+
+Reasoning: expert-tla's memoryless-between-runs argument is convincing. ClearStateFile resets all state variables, so a third run adds no new reachable states. The README should document this rationale. The property-to-test mapping is a documentation enhancement, not a spec change.
+
+Objections:
+- None new.
+
+Endorsements:
+- expert-tla: Memoryless-between-runs argument for MaxRuns = 2.
+- expert-edge-cases: ClearStateFile gitState fix.
+- expert-continuous-delivery: ClearStateFile gitState fix.
+
+---
+
+### expert-continuous-delivery
+
+Position: Satisfied. The gitState fix is the key deliverable.
+
+Reasoning: The council has converged on ClearStateFile setting gitState = DIRTY. With this fix, the git lifecycle becomes: CLEAN (initial, file never existed) -> DIRTY (after any file write) -> COMMITTED (after explicit commit at terminal state). This correctly models the CD lifecycle. Expert-edge-cases' note about clearFailed deadlock being intentional should be documented.
+
+Objections:
+- None new.
+
+Endorsements:
+- expert-tla: Full state model analysis and memoryless-between-runs argument.
+- expert-edge-cases: clearFailed deadlock documentation.
+
+---
+
+## Round 2 -- Moderator Analysis
+
+**New objections raised in Round 2:** None.
+
+All prior objections are resolved, addressed by recommended changes, or acknowledged as non-blocking. No expert raised a new concern.
+
+**Consensus reached after Round 2.**
+
+---
+
+## Agreed Recommendation
+
+The TLA+ specification `GlobalPipelineState.tla` is a faithful formalization of the design consensus with **one correctness issue** and **three documentation/hardening improvements**.
+
+### 1. FIX: ClearStateFile should set gitState to DIRTY, not CLEAN
+
+**Priority: HIGH (correctness)**
+
+The ClearStateFile action sets `gitState' = "CLEAN"` on success. In reality, writing a template file to disk changes the file, producing an uncommitted git change. The spec should set `gitState' = "DIRTY"` after clearing. The CLEAN state should only be reachable as the initial state (file never existed) or via explicit commit.
+
+This fix also strengthens EventualCommit: with gitState = DIRTY after clearing, the liveness property becomes more meaningful because the system cannot reach CLEAN without an actual commit.
+
+**Impact on other properties:** WarnUncommitted and the ClearStateFile guard (`gitState /= "DIRTY" \/ warned = TRUE`) may need adjustment. After a commit at terminal state, gitState = COMMITTED. Then ClearStateFile fires with gitState = COMMITTED, which passes the guard (not DIRTY). After clearing, gitState = DIRTY. This is correct.
+
+For the ABSENT -> CLEARED initial transition: gitState starts CLEAN, ClearStateFile fires, gitState' = DIRTY. WarnUncommitted guard (`gitState /= "DIRTY" \/ warned = TRUE`) -- since gitState is CLEAN (ABSENT state), the guard passes. After clearing, gitState = DIRTY. This is correct for the first run.
+
+### 2. ADD: Invariant -- CLEARED implies all sections EMPTY
+
+```tla
+ClearedSectionsEmpty ==
+    fileState = "CLEARED" => \A s \in Stages : sections[s] = "EMPTY"
+```
+
+This invariant is trivially true given ClearStateFile's action, but making it explicit documents the intent and catches future regressions.
+
+### 3. ADD: Invariant -- halted consistency
+
+```tla
+HaltedConsistency ==
+    halted = TRUE <=> fileState = "HALTED_SNAPSHOT"
+```
+
+The `halted` boolean is redundant with fileState but improves readability. A consistency invariant prevents them from diverging.
+
+### 4. DOCUMENT: README enhancements
+
+- **MaxRuns = 2 justification:** The state machine is memoryless between runs -- ClearStateFile resets all variables. A third run explores the same state space as the second.
+- **clearFailed deadlock:** The clearFailed = TRUE state is intentionally a deadlock (no outgoing transitions). This is the fail-fast behavior from the design consensus. No liveness guarantee applies.
+- **Property-to-test mapping (optional):** For each safety/liveness property, document the corresponding implementation test scenario.
+
+### Non-Blocking Recommendations
+
+- **Domain naming:** The spec uses generic terms (sections, fileState, writtenBy) where the design consensus adopted domain terms (stageResults, snapshotState, PipelineRunSnapshot). This is a style improvement, not a correctness issue.
+- **EventualCommit naming:** Consider renaming to EventualCommitOrNextRun to accurately reflect what the property proves.
+
+---
+
+## Expert Final Positions
+
+**expert-tla**
+Position: The spec is sound with the gitState fix applied. All safety and liveness properties correctly formalize the design consensus once ClearStateFile sets DIRTY instead of CLEAN.
+Key reasoning: The three-machine decomposition, state enumeration, and safety properties are correct. The gitState fix is the only correctness issue. The consistency invariant for `halted` and the CLEARED-sections invariant are hardening additions. MaxRuns = 2 is justified by the memoryless-between-runs property of ClearStateFile.
+Endorsed: expert-edge-cases (gitState fix), expert-continuous-delivery (gitState fix), expert-ddd (halted consistency)
+
+**expert-edge-cases**
+Position: The spec addresses all three critical edge cases from the design debate once the gitState fix is applied. Validation failure is correctly abstracted out of the formal model.
+Key reasoning: Clear failure is modeled (clearFailed + fail-fast). Uncommitted changes are modeled (WarnUncommitted + ClearStateFile guard). The gitState fix is the most impactful change. ValidateSection's always-succeeds model is a valid abstraction for the formal spec.
+Endorsed: expert-tla (memoryless argument), expert-continuous-delivery (gitState fix), expert-ddd (halted consistency)
+
+**expert-ddd**
+Position: The spec is functionally correct. Domain naming is a non-blocking style improvement.
+Key reasoning: The `halted` boolean redundancy is the only structural concern. A consistency invariant resolves it. Domain naming (stageResults vs sections) would improve the spec as documentation but does not affect verification.
+Endorsed: expert-tla (consistency invariant approach), expert-edge-cases (ValidateSection withdrawal)
+
+**expert-tdd**
+Position: TLC results are credible once MaxRuns = 2 is justified in the README.
+Key reasoning: The memoryless-between-runs argument is convincing. The property-to-test mapping is a valuable documentation enhancement. The gitState fix is the top priority.
+Endorsed: expert-tla (memoryless argument), expert-edge-cases (gitState fix), expert-continuous-delivery (gitState fix)
+
+**expert-continuous-delivery**
+Position: Machine 3 (GitCommitProtocol) correctly models the CD lifecycle once ClearStateFile sets DIRTY.
+Key reasoning: Every file mutation should produce DIRTY. Only explicit commits produce COMMITTED. CLEAN is the initial state only. The clearFailed deadlock is correct fail-fast behavior.
+Endorsed: expert-tla (full state analysis), expert-edge-cases (clearFailed documentation)
+
+---
+
+## Endorsement Map
+
+| Expert | Endorsed By |
+|---|---|
+| expert-tla (memoryless argument, consistency invariants) | expert-edge-cases, expert-tdd, expert-ddd, expert-continuous-delivery |
+| expert-edge-cases (gitState fix, clearFailed documentation) | expert-tla, expert-tdd, expert-continuous-delivery |
+| expert-ddd (halted consistency, naming) | expert-tla, expert-edge-cases |
+| expert-tdd (MaxRuns justification, property-to-test mapping) | expert-tla |
+| expert-continuous-delivery (gitState as CD lifecycle) | expert-tla, expert-edge-cases, expert-tdd |
+
+---
+
+**Session saved to:** docs/debate-moderator-sessions/2026-04-02_global-pipeline-state-tla-review.md

--- a/docs/design-pipeline-sessions/2026-04-02_global-pipeline-state.md
+++ b/docs/design-pipeline-sessions/2026-04-02_global-pipeline-state.md
@@ -1,0 +1,59 @@
+# Design Pipeline Session — Global Pipeline State
+
+**Date:** 2026-04-02
+**Status:** IN PROGRESS
+**Current Stage:** STAGE_6_CONFIRMATION_GATE
+**Restart Count:** 0
+
+---
+
+## Stage 1 — Questioner
+**Status:** COMPLETE
+**Briefing:** `docs/questioner-sessions/2026-04-02_global-pipeline-state.md`
+**Experts Selected:** autonomous (debate-moderator selects via selectExperts)
+
+## Stage 2 — Design Debate
+**Status:** COMPLETE
+**Synthesis:** `docs/debate-moderator-sessions/2026-04-02_global-pipeline-state-design.md`
+**Rounds:** 2
+**Result:** CONSENSUS REACHED
+
+## Stage 3 — TLA+ Writer
+**Status:** COMPLETE
+**Spec Directory:** `docs/tla-specs/global-pipeline-state/`
+**TLC Result:** PASS (small: 467 distinct states, production: 1,907 distinct states) — v2 post-review
+**Retry Count:** 1
+
+## Stage 4 — TLA+ Review
+**Status:** COMPLETE (v2 re-review passed)
+**Synthesis:** `docs/debate-moderator-sessions/2026-04-02_global-pipeline-state-tla-review-v2.md`
+**Rounds:** 1 (re-review)
+**Result:** CONSENSUS REACHED
+
+## Stage 5 — Implementation Plan
+**Status:** COMPLETE
+**Plan:** `docs/implementation/2026-04-02_global-pipeline-state.md`
+**Unmapped States:** None
+**Tiers:** 5
+**Tasks:** 10
+
+## Stage 6 — Pair Programming
+**Status:** PENDING
+**Integration Branch:** `design-pipeline/global-pipeline-state`
+**Current Tier:** _pending_
+**Current Pipeline State:** _pending_
+**Global Fix Count:** 0
+**Halt Reason:** N/A
+
+### Tier Progress
+_pending_
+
+### Session Log
+_pending_
+
+---
+
+## Iteration Log
+| Iteration | From Stage | To Stage | Reason | Timestamp |
+|---|---|---|---|---|
+| 1 | Stage 4 (TLA+ Review) | Stage 3 (TLA+ Writer) | gitState fix + 2 new invariants from review | 2026-04-02 |

--- a/docs/implementation/2026-04-02_global-pipeline-state.md
+++ b/docs/implementation/2026-04-02_global-pipeline-state.md
@@ -1,0 +1,542 @@
+# Implementation Plan: Global Pipeline State File
+
+## Source Artifacts
+
+| Artifact | Path |
+|----------|------|
+| Briefing | `docs/questioner-sessions/2026-04-02_global-pipeline-state.md` |
+| Design Consensus | `docs/debate-moderator-sessions/2026-04-02_global-pipeline-state-design.md` |
+| TLA+ Specification | `docs/tla-specs/global-pipeline-state/GlobalPipelineState.tla` |
+| TLA+ Review Consensus | `docs/debate-moderator-sessions/2026-04-02_global-pipeline-state-tla-review-v2.md` |
+
+## TLA+ State Coverage Matrix
+
+### States
+
+**File Lifecycle (Machine 1):**
+- `ABSENT` -- file does not exist (before first pipeline run)
+- `CLEARED` -- template written with section headers and empty values
+- `ACCUMULATING` -- at least one stage has written its StageResult
+- `COMPLETE_SNAPSHOT` -- pipeline completed successfully
+- `HALTED_SNAPSHOT` -- pipeline halted due to failure
+
+**Section States (Machine 2):**
+- `EMPTY` -- section header present, no content
+- `WRITTEN` -- populated by owning stage
+- `VALIDATED` -- validated by a subsequent stage before writing
+
+**Git States (Machine 3):**
+- `CLEAN` -- no uncommitted changes (initial only)
+- `DIRTY` -- state file has uncommitted changes
+- `COMMITTED` -- terminal state committed to git
+
+**Boolean Flags:**
+- `clearFailed` -- whether the clear operation failed (TRUE = intentional deadlock / fail-fast)
+- `halted` -- whether current run halted
+- `warned` -- whether uncommitted-change warning was issued
+
+### Transitions
+
+- `ClearStateFile` -- clear the state file to template at run start (ABSENT/COMPLETE_SNAPSHOT/HALTED_SNAPSHOT -> CLEARED, or sets clearFailed=TRUE)
+- `StartRun` -- begin pipeline execution (CLEARED -> currentStage=1)
+- `WriteStageResult(stage)` -- a stage writes its own section (CLEARED/ACCUMULATING -> ACCUMULATING)
+- `ValidateSection(stage)` -- validate a prior stage's section before writing (WRITTEN -> VALIDATED)
+- `AdvanceStage` -- move to the next stage (currentStage increments)
+- `CompletePipeline` -- pipeline completes successfully (ACCUMULATING -> COMPLETE_SNAPSHOT)
+- `HaltPipeline` -- pipeline halts (CLEARED/ACCUMULATING -> HALTED_SNAPSHOT)
+- `WarnUncommitted` -- warn about uncommitted changes before clearing (sets warned=TRUE)
+- `CommitStateFile` -- commit at terminal state only (DIRTY -> COMMITTED)
+
+### Safety Invariants
+
+- `TypeOK` -- all variables within declared domains
+- `SectionOwnership` -- each stage's section is written only by its owning stage (writtenBy[s] is 0 or s)
+- `NoStageSkip` -- stage N written only after all stages 1..(N-1) are written
+- `ClearOnStart` -- when a run is active, all unwritten sections are EMPTY
+- `FailFastOnClearFailure` -- if clear failed, pipeline does not start (clearFailed=TRUE => currentStage=0)
+- `SchemaValidationInvariant` -- when a stage writes, all prior stages are populated
+- `TerminalStateOnlyCommit` -- state file committed only at COMPLETE_SNAPSHOT or HALTED_SNAPSHOT
+- `UncommittedWarningProtocol` -- warned=TRUE only when gitState is DIRTY or COMMITTED
+- `ClearedSectionsEmpty` -- when fileState is CLEARED, every section is EMPTY
+- `HaltedConsistency` -- halted=TRUE if and only if fileState=HALTED_SNAPSHOT
+
+### Liveness Properties
+
+- `Progress` -- if a pipeline run starts (CLEARED), it eventually reaches COMPLETE_SNAPSHOT or HALTED_SNAPSHOT
+- `EventualCommit` -- if the file reaches a terminal state, it is eventually committed
+
+---
+
+## Implementation Steps
+
+### Step 1: Create the pipeline-state.md template file
+
+**Files:**
+- `docs/pipeline-state.md` (create)
+
+**Description:**
+Create the state file at its canonical location with the template structure. The template represents the CLEARED state: it contains section headers for the pipeline run metadata and each of the 6 stages, with empty/default values. Each section uses domain language -- the file-level concept is a PipelineRunSnapshot, and each stage section is a StageResult. The template must be deterministic so that clearing the file means overwriting with this exact content.
+
+The template structure includes:
+- A header identifying this as the pipeline state file
+- Run-level metadata: run status (CLEARED), topic, start timestamp, current stage
+- One StageResult section per stage (1-6), each with: stage name, status (empty), artifact path (empty), timestamp (empty)
+- A Git Commit section: committed (no), halt reason (empty)
+
+**Dependencies:** None
+
+**Test (write first):**
+Write a test that reads `docs/pipeline-state.md` and asserts:
+1. The file exists
+2. It contains exactly 6 StageResult sections (identifiable by a consistent heading pattern like `## Stage N --`)
+3. Each StageResult section contains the fields: Status, Artifact, Timestamp -- all with empty/default values
+4. The run-level metadata section exists with Status field set to `CLEARED`
+5. A Git Commit section exists with Committed field set to `no`
+
+The test parses the markdown by splitting on `##` headings and checking field patterns. Inputs: the file on disk. Expected outcome: all assertions pass against the template content.
+
+**TLA+ Coverage:**
+- State: `ABSENT` (before file exists -- test verifies creation from nothing)
+- State: `CLEARED` (the template IS the CLEARED state)
+- State: `EMPTY` (all sections are EMPTY in the template)
+- Transition: `ClearStateFile` (the template is what ClearStateFile produces)
+- Invariant: `ClearedSectionsEmpty` (template has all sections empty)
+- Invariant: `TypeOK` (the template establishes the initial shape)
+
+---
+
+### Step 2: Clean stale expert-selection references from design-pipeline SKILL.md
+
+**Files:**
+- `.claude/skills/design-pipeline/SKILL.md` (modify)
+
+**Description:**
+Remove all references to expert selection being a questioner/Stage 1 responsibility. After PR #40, expert selection is the debate-moderator's autonomous `selectExperts(topic)` function. The following specific changes are required (per design consensus item 8):
+
+1. **Frontmatter description (line 3):** Remove "expert selection" language if present
+2. **Pipeline stages diagram (line 29):** Change Stage 1 label from "elicit requirements + expert selection" to "elicit requirements"
+3. **Stage 1 input framing (lines 155-161):** Remove the Expert Council section instruction. Replace with simplified framing that just asks the questioner to save the briefing and return it
+4. **Stage 1 output (line 163):** Remove "including the Expert Council section"
+5. **Stage 1 on-completion (line 164-165):** Remove "Extract the expert list from the Expert Council section." Change "Add briefing and expert list to accumulated context" to "Add briefing to accumulated context"
+6. **Stage 2 input (line 174):** Remove the `Experts:` parameter line
+7. **Stage 4 input (line 242):** Remove the `Experts:` parameter line
+8. **Accumulated context table (lines 136-143):** Remove "expert list" from Stage 1 row and all subsequent rows
+9. **Constraints section (line 713):** Remove the constraint about expert selection reuse across stages
+
+**Dependencies:** None
+
+**Test (write first):**
+Write a test that reads `.claude/skills/design-pipeline/SKILL.md` and asserts:
+1. The file does NOT contain the string "Expert Council" (case-sensitive)
+2. The file does NOT contain "expert list" as a table cell value in the accumulated context table
+3. The file does NOT contain "expert selection" in the frontmatter description
+4. The Stage 1 diagram label does NOT contain "expert selection"
+5. The file does NOT contain the constraint "Expert selection from Stage 1 is reused"
+6. The Stages 2 and 4 input sections do NOT contain an `Experts:` parameter line that references Stage 1
+
+Inputs: the SKILL.md file content. Expected outcome: all negative assertions pass (none of the stale references exist).
+
+**TLA+ Coverage:**
+- This step does not directly map to a TLA+ state or transition. It is a prerequisite cleanup required by the design consensus (item 8) that removes stale documentation from the file that will receive state-file lifecycle instructions in Step 4.
+
+---
+
+### Step 3: Shed state documentation from design-pipeline SKILL.md
+
+**Files:**
+- `.claude/skills/design-pipeline/SKILL.md` (modify)
+
+**Description:**
+Remove the state-tracking documentation from SKILL.md that is being replaced by the state file. The SKILL.md should focus purely on behavioral instructions. Specifically:
+
+1. **Pipeline Change Tracking section (lines 118-130):** Remove the `changeFlag` description. The changeFlag concept remains in the pipeline but its documentation moves to the state file where the flag lives.
+2. **Accumulated Context table (lines 136-143):** Remove the table entirely. The state file tracks what context has been accumulated. The behavioral instructions for what each stage passes forward remain in the stage execution sections.
+3. **Session File section (lines 558-628):** Remove the entire Session File section including the format template. The state file replaces the session index.
+4. **Session File format description and output location for Pipeline Session Index:** Remove the row from the Output Locations table (line 662) referencing `docs/design-pipeline-sessions/`.
+5. **Handoff section references to session index:** Update to reference the state file instead of the session index.
+
+**Dependencies:** Step 2 (expert-selection cleanup must happen first so we are working on a clean file)
+
+**Test (write first):**
+Write a test that reads `.claude/skills/design-pipeline/SKILL.md` and asserts:
+1. The file does NOT contain the heading `## Pipeline Change Tracking` (the section is removed)
+2. The file does NOT contain the heading `## Accumulated Context` as a standalone section with a table (behavioral stage instructions may still reference accumulated context as a concept)
+3. The file does NOT contain the heading `### Session File Format`
+4. The file does NOT contain `docs/design-pipeline-sessions/` anywhere
+5. The file does NOT contain `Pipeline Session Index` in the Output Locations table
+6. The file DOES still contain stage execution sections (Stage 1 through Stage 6) -- we only removed state docs, not behavior docs
+
+Inputs: the SKILL.md file content. Expected outcome: all assertions pass.
+
+**TLA+ Coverage:**
+- This step removes the old state-tracking approach, making room for the state file. It is a prerequisite for Step 4 which adds state-file lifecycle instructions.
+- Indirectly supports all Machine 1 states by establishing that the state file (not SKILL.md) is the single source of truth.
+
+---
+
+### Step 4: Add state file lifecycle instructions to design-pipeline SKILL.md
+
+**Files:**
+- `.claude/skills/design-pipeline/SKILL.md` (modify)
+
+**Description:**
+Add a new section to SKILL.md documenting the state file lifecycle and the orchestrator's responsibilities. This section replaces the removed state documentation with behavioral instructions for how the orchestrator interacts with the state file. The content covers:
+
+1. **State File Location:** `docs/pipeline-state.md`
+2. **Clear on Start:** At the start of each pipeline run, overwrite the state file with the template (CLEARED state). If the clear operation fails, do not start the pipeline (fail-fast).
+3. **Uncommitted-Change Warning:** Before clearing, check `git status` on the state file. If there are uncommitted changes (DIRTY), warn the user. Do not block -- warn only.
+4. **Section Ownership:** Each stage writes only its own StageResult section. Cross-section writes are domain invariant violations.
+5. **Schema Validation:** Each stage validates that the state file is well-formed (all prior StageResult sections are present and parseable) before writing its own section.
+6. **Terminal-State-Only Commits:** The state file is committed only when the pipeline reaches COMPLETE or HALTED. Intermediate states are transient.
+7. **Session Index Elimination:** Note that the `docs/design-pipeline-sessions/` directory has been eliminated. The state file + git history replaces it.
+8. **Update the COMPLETE and HALTED presentation blocks** to reference the state file path instead of the session index path.
+9. **Update Output Locations table** to include the state file and remove the session index entry.
+
+**Dependencies:** Step 1 (template must exist), Step 3 (state docs must be removed first)
+
+**Test (write first):**
+Write a test that reads `.claude/skills/design-pipeline/SKILL.md` and asserts:
+1. The file contains a section about the state file (heading containing "State File" or "Pipeline State")
+2. That section contains the string `docs/pipeline-state.md`
+3. The file contains the phrase "fail-fast" in the context of clear failure
+4. The file contains the phrase "section ownership" or "SectionOwnership" or "section-scoped ownership"
+5. The file contains the phrase "schema validation" or "validates" in the context of prior stages
+6. The file contains the phrase "terminal" in the context of commits (terminal-state-only commits)
+7. The file contains "uncommitted" in the context of warning before clearing
+8. The Output Locations table includes `docs/pipeline-state.md`
+9. The COMPLETE presentation block references the state file path
+10. The HALTED presentation block references the state file path
+
+Inputs: the SKILL.md file content. Expected outcome: all assertions pass.
+
+**TLA+ Coverage:**
+- Transition: `ClearStateFile` (clear on start instruction)
+- Transition: `WarnUncommitted` (uncommitted-change warning instruction)
+- Transition: `CommitStateFile` (terminal-state-only commit instruction)
+- Invariant: `FailFastOnClearFailure` (fail-fast instruction)
+- Invariant: `SectionOwnership` (section ownership instruction)
+- Invariant: `SchemaValidationInvariant` (schema validation instruction)
+- Invariant: `TerminalStateOnlyCommit` (terminal-state-only commit instruction)
+- Invariant: `UncommittedWarningProtocol` (uncommitted warning instruction)
+- Invariant: `ClearOnStart` (clear on start instruction)
+- State: `CLEARED` (template-based clearing)
+- State: `COMPLETE_SNAPSHOT` (terminal state handling)
+- State: `HALTED_SNAPSHOT` (terminal state handling)
+
+---
+
+### Step 5: Add state file write instructions to questioner SKILL.md (Stage 1)
+
+**Files:**
+- `.claude/skills/questioner/SKILL.md` (modify)
+
+**Description:**
+Add instructions to the questioner skill telling it to write its StageResult section in `docs/pipeline-state.md` when called from the design pipeline. The questioner writes the Stage 1 section with: status (COMPLETE or INCOMPLETE), artifact path (briefing file path), and timestamp. The questioner must validate that the state file exists and is in CLEARED or ACCUMULATING state before writing. The questioner writes only to its own section -- the Stage 1 StageResult.
+
+This instruction should be conditioned on being called from the design pipeline (the questioner is also used standalone). A pipeline-run flag or the presence of the state file in CLEARED state indicates pipeline context.
+
+**Dependencies:** Step 1 (template must exist)
+
+**Test (write first):**
+Write a test that reads `.claude/skills/questioner/SKILL.md` and asserts:
+1. The file contains a reference to `docs/pipeline-state.md` or `pipeline-state.md`
+2. The file contains instructions about writing a StageResult (the term "StageResult" or "Stage 1" section in the state file)
+3. The file contains a condition for pipeline context (e.g., "when called from the design pipeline" or "pipeline run")
+
+Inputs: the SKILL.md file content. Expected outcome: all assertions pass.
+
+**TLA+ Coverage:**
+- Transition: `WriteStageResult(1)` (Stage 1 writes its section)
+- State: `WRITTEN` (section state after questioner writes)
+- Invariant: `SectionOwnership` (questioner writes only Stage 1)
+- Invariant: `NoStageSkip` (Stage 1 has no prior stages to check)
+
+---
+
+### Step 6: Add state file write instructions to debate-moderator SKILL.md (Stages 2 and 4)
+
+**Files:**
+- `.claude/skills/orchestrators/debate-moderator/SKILL.md` (modify)
+
+**Description:**
+Add instructions to the debate-moderator skill telling it to write StageResult sections in `docs/pipeline-state.md` when called from the design pipeline. The debate-moderator is used for two stages:
+
+- **Stage 2 (Design Debate):** Writes the Stage 2 StageResult with: status (CONSENSUS REACHED or PARTIAL CONSENSUS), artifact path (debate session file path), rounds count, and timestamp.
+- **Stage 4 (TLA+ Review):** Writes the Stage 4 StageResult with: status (CONSENSUS REACHED or OBJECTIONS NOTED), artifact path (review session file path), rounds count, and timestamp.
+
+Before writing, the debate-moderator validates that all prior StageResult sections are present and well-formed (schema validation). The debate-moderator writes only to its own stage's section -- Stage 2 or Stage 4, depending on which pipeline stage dispatched it.
+
+**Dependencies:** Step 1 (template must exist), Step 5 (Stage 1 must write first in execution order, but the file modification is independent)
+
+**Test (write first):**
+Write a test that reads `.claude/skills/orchestrators/debate-moderator/SKILL.md` and asserts:
+1. The file contains a reference to `docs/pipeline-state.md` or `pipeline-state.md`
+2. The file contains instructions about writing Stage 2 and Stage 4 StageResult sections
+3. The file contains instructions about validating prior sections before writing
+
+Inputs: the SKILL.md file content. Expected outcome: all assertions pass.
+
+**TLA+ Coverage:**
+- Transition: `WriteStageResult(2)` (Stage 2 writes its section)
+- Transition: `WriteStageResult(4)` (Stage 4 writes its section)
+- Transition: `ValidateSection(s)` (debate-moderator validates prior sections)
+- State: `WRITTEN` (section state after debate-moderator writes)
+- State: `VALIDATED` (prior sections validated before writing)
+- Invariant: `SectionOwnership` (debate-moderator writes only its assigned stage)
+- Invariant: `NoStageSkip` (validates prior stages exist)
+- Invariant: `SchemaValidationInvariant` (validates prior sections are well-formed)
+
+---
+
+### Step 7: Add state file write instructions to tla-writer AGENT.md (Stage 3)
+
+**Files:**
+- `.claude/skills/tla-writer/AGENT.md` (modify)
+
+**Description:**
+Add instructions to the tla-writer agent telling it to write its StageResult section in `docs/pipeline-state.md` when called from the design pipeline. The tla-writer writes the Stage 3 StageResult with: status (COMPLETE or UNVERIFIED), artifact path (TLA+ spec directory path), TLC result (PASS or FAIL), retry count, and timestamp. Before writing, the tla-writer validates that all prior StageResult sections (Stages 1-2) are present and well-formed.
+
+**Dependencies:** Step 1 (template must exist)
+
+**Test (write first):**
+Write a test that reads `.claude/skills/tla-writer/AGENT.md` and asserts:
+1. The file contains a reference to `docs/pipeline-state.md` or `pipeline-state.md`
+2. The file contains instructions about writing a Stage 3 StageResult section
+3. The file contains instructions about validating prior sections before writing
+
+Inputs: the AGENT.md file content. Expected outcome: all assertions pass.
+
+**TLA+ Coverage:**
+- Transition: `WriteStageResult(3)` (Stage 3 writes its section)
+- Transition: `ValidateSection(s)` (tla-writer validates prior sections)
+- State: `WRITTEN` (section state after tla-writer writes)
+- Invariant: `SectionOwnership` (tla-writer writes only Stage 3)
+- Invariant: `NoStageSkip` (validates Stages 1-2 exist)
+- Invariant: `SchemaValidationInvariant` (validates prior sections are well-formed)
+
+---
+
+### Step 8: Add state file write instructions to implementation-writer AGENT.md (Stage 5)
+
+**Files:**
+- `.claude/skills/implementation-writer/AGENT.md` (modify)
+
+**Description:**
+Add instructions to the implementation-writer agent telling it to write its StageResult section in `docs/pipeline-state.md` when called from the design pipeline. The implementation-writer writes the Stage 5 StageResult with: status (COMPLETE), artifact path (implementation plan file path), tiers count, tasks count, unmapped states (list or "None"), and timestamp. Before writing, the implementation-writer validates that all prior StageResult sections (Stages 1-4) are present and well-formed.
+
+**Dependencies:** Step 1 (template must exist)
+
+**Test (write first):**
+Write a test that reads `.claude/skills/implementation-writer/AGENT.md` and asserts:
+1. The file contains a reference to `docs/pipeline-state.md` or `pipeline-state.md`
+2. The file contains instructions about writing a Stage 5 StageResult section
+3. The file contains instructions about validating prior sections before writing
+
+Inputs: the AGENT.md file content. Expected outcome: all assertions pass.
+
+**TLA+ Coverage:**
+- Transition: `WriteStageResult(5)` (Stage 5 writes its section)
+- Transition: `ValidateSection(s)` (implementation-writer validates prior sections)
+- State: `WRITTEN` (section state after implementation-writer writes)
+- Invariant: `SectionOwnership` (implementation-writer writes only Stage 5)
+- Invariant: `NoStageSkip` (validates Stages 1-4 exist)
+- Invariant: `SchemaValidationInvariant` (validates prior sections are well-formed)
+
+---
+
+### Step 9: Add state file write instructions to design-pipeline SKILL.md for Stage 6
+
+**Files:**
+- `.claude/skills/design-pipeline/SKILL.md` (modify)
+
+**Description:**
+Add instructions within the Stage 6 section of the design-pipeline SKILL.md specifying that the orchestrator writes the Stage 6 StageResult section in `docs/pipeline-state.md`. The orchestrator writes Stage 6 with: status (COMPLETE or HALTED), integration branch name, tiers completed, tasks completed/total, global fix count, halt reason (if applicable), and timestamp. Before writing, validate that all prior StageResult sections (Stages 1-5) are present and well-formed.
+
+Additionally, this step updates the terminal state handling (COMPLETE and HALTED presentation blocks) to:
+1. Write the final file-level status (COMPLETE or HALTED) to the run metadata section
+2. Commit the state file as part of the terminal artifact
+
+**Dependencies:** Step 4 (state file lifecycle instructions must be in place)
+
+**Test (write first):**
+Write a test that reads `.claude/skills/design-pipeline/SKILL.md` and asserts:
+1. The Stage 6 section contains a reference to writing the Stage 6 StageResult in `pipeline-state.md`
+2. The COMPLETE block references committing the state file
+3. The HALTED block references committing the state file
+4. The Stage 6 section contains instructions about validating prior sections
+
+Inputs: the SKILL.md file content. Expected outcome: all assertions pass.
+
+**TLA+ Coverage:**
+- Transition: `WriteStageResult(6)` (Stage 6 writes its section)
+- Transition: `CompletePipeline` (file-level status set to COMPLETE_SNAPSHOT)
+- Transition: `HaltPipeline` (file-level status set to HALTED_SNAPSHOT)
+- Transition: `CommitStateFile` (terminal commit at COMPLETE or HALTED)
+- State: `COMPLETE_SNAPSHOT` (pipeline completes)
+- State: `HALTED_SNAPSHOT` (pipeline halts)
+- Invariant: `SectionOwnership` (orchestrator writes only Stage 6)
+- Invariant: `NoStageSkip` (validates Stages 1-5 exist)
+- Invariant: `TerminalStateOnlyCommit` (commit only at terminal states)
+- Invariant: `HaltedConsistency` (halted flag and file state agree)
+
+---
+
+### Step 10: Integration test -- full state file lifecycle
+
+**Files:**
+- Test file alongside the state file validation tests (same test file as Steps 1, 5-9, extended)
+
+**Description:**
+Write an integration test that validates the full lifecycle of the state file by checking all SKILL.md and AGENT.md files together. This test ensures the entire pipeline's state file contract is coherent across all participating agents.
+
+**Dependencies:** Steps 1-9 (all prior steps must be complete)
+
+**Test (write first):**
+Write an integration test that:
+1. Reads all participating agent files (questioner SKILL.md, debate-moderator SKILL.md, tla-writer AGENT.md, implementation-writer AGENT.md, design-pipeline SKILL.md)
+2. Asserts each file references `pipeline-state.md`
+3. Asserts each file's stage number is mentioned in the context of StageResult writes
+4. Asserts the design-pipeline SKILL.md contains fail-fast, uncommitted warning, terminal-state-only commit, and section ownership concepts
+5. Asserts the template file (`docs/pipeline-state.md`) contains exactly 6 stage sections matching the 6 pipeline stages
+6. Asserts no file references `docs/design-pipeline-sessions/` (session index eliminated)
+
+Inputs: all agent/skill files + the template. Expected outcome: all assertions pass.
+
+**TLA+ Coverage:**
+- Invariant: `SectionOwnership` (all agents write only their own section)
+- Invariant: `NoStageSkip` (sequential coverage validated)
+- Invariant: `ClearOnStart` (template structure validated)
+- Invariant: `FailFastOnClearFailure` (instruction presence validated)
+- Invariant: `TerminalStateOnlyCommit` (instruction presence validated)
+- Invariant: `UncommittedWarningProtocol` (instruction presence validated)
+- Invariant: `SchemaValidationInvariant` (validation instruction presence validated)
+- Liveness: `Progress` (all stages have write instructions, enabling forward progress)
+- Liveness: `EventualCommit` (terminal commit instructions present)
+
+---
+
+## State Coverage Audit
+
+### States
+
+| State | Covered By |
+|-------|-----------|
+| `ABSENT` | Step 1 (test verifies creation from nothing) |
+| `CLEARED` | Step 1 (template IS the CLEARED state), Step 4 (clear-on-start instruction) |
+| `ACCUMULATING` | Steps 5-9 (each stage's WriteStageResult transitions to ACCUMULATING) |
+| `COMPLETE_SNAPSHOT` | Step 9 (CompletePipeline transition), Step 4 (terminal handling) |
+| `HALTED_SNAPSHOT` | Step 9 (HaltPipeline transition), Step 4 (terminal handling) |
+| `EMPTY` | Step 1 (template sections are EMPTY) |
+| `WRITTEN` | Steps 5-9 (each stage writes its section) |
+| `VALIDATED` | Steps 6-9 (each stage validates prior sections) |
+| `CLEAN` | Step 4 (initial git state, implicitly handled -- only at Init) |
+| `DIRTY` | Step 4 (state file has uncommitted changes after any write) |
+| `COMMITTED` | Step 4, Step 9 (terminal-state-only commit instruction) |
+| `clearFailed=TRUE` | Step 4 (fail-fast instruction) |
+| `halted=TRUE` | Step 9 (HALTED handling) |
+| `warned=TRUE` | Step 4 (uncommitted-change warning instruction) |
+
+### Transitions
+
+| Transition | Covered By |
+|-----------|-----------|
+| `ClearStateFile` | Step 1 (template creation), Step 4 (clear-on-start instruction) |
+| `StartRun` | Step 4 (lifecycle instructions -- pipeline starts after clearing) |
+| `WriteStageResult(1)` | Step 5 |
+| `WriteStageResult(2)` | Step 6 |
+| `WriteStageResult(3)` | Step 7 |
+| `WriteStageResult(4)` | Step 6 |
+| `WriteStageResult(5)` | Step 8 |
+| `WriteStageResult(6)` | Step 9 |
+| `ValidateSection(s)` | Steps 6-9 (each validates prior sections) |
+| `AdvanceStage` | Step 4 (lifecycle instructions -- stages advance sequentially) |
+| `CompletePipeline` | Step 9 (terminal handling) |
+| `HaltPipeline` | Step 9 (terminal handling) |
+| `WarnUncommitted` | Step 4 (uncommitted-change warning instruction) |
+| `CommitStateFile` | Step 4, Step 9 (terminal-state-only commit) |
+
+### Safety Invariants
+
+| Invariant | Verified By |
+|-----------|------------|
+| `TypeOK` | Step 1 (template establishes shape), Step 10 (integration test) |
+| `SectionOwnership` | Steps 5-9 (each agent writes only its section), Step 10 |
+| `NoStageSkip` | Steps 6-9 (validate prior stages), Step 10 |
+| `ClearOnStart` | Step 1 (template), Step 4 (clear instruction), Step 10 |
+| `FailFastOnClearFailure` | Step 4 (fail-fast instruction), Step 10 |
+| `SchemaValidationInvariant` | Steps 6-9 (validate prior sections), Step 10 |
+| `TerminalStateOnlyCommit` | Step 4 (terminal commit instruction), Step 9, Step 10 |
+| `UncommittedWarningProtocol` | Step 4 (warning instruction), Step 10 |
+| `ClearedSectionsEmpty` | Step 1 (template has all sections empty) |
+| `HaltedConsistency` | Step 9 (halted handling aligns with file state) |
+
+### Liveness Properties
+
+| Property | Verified By |
+|----------|------------|
+| `Progress` | Step 10 (all stages have write instructions, enabling forward progress) |
+| `EventualCommit` | Step 4 (terminal commit instruction), Step 9 (commit at COMPLETE/HALTED), Step 10 |
+
+All TLA+ states, transitions, and properties are covered by the implementation plan.
+
+---
+
+## Execution Tiers
+
+### Tier 1: Foundation (independent work -- no cross-dependencies)
+
+These tasks can execute in parallel because they touch different files with no shared dependencies. Step 1 creates a new file; Steps 2 and 3 modify the same file but must be serialized (Step 3 depends on Step 2). Steps 5, 7, and 8 each modify different agent files.
+
+| Task ID | Step | Title |
+|---------|------|-------|
+| T1 | Step 1 | Create pipeline-state.md template |
+| T2 | Step 2 | Clean stale expert-selection references |
+
+### Tier 2: SKILL.md state documentation (depends on Tier 1 -- Step 3 requires Step 2 complete)
+
+Step 3 modifies the same file as Step 2 (design-pipeline SKILL.md) and depends on the expert-selection cleanup being done first. Steps 5, 7, and 8 modify independent agent files and can run in parallel.
+
+| Task ID | Step | Title |
+|---------|------|-------|
+| T3 | Step 3 | Shed state documentation from SKILL.md |
+| T4 | Step 5 | Add state file write instructions to questioner |
+| T5 | Step 7 | Add state file write instructions to tla-writer |
+| T6 | Step 8 | Add state file write instructions to implementation-writer |
+
+### Tier 3: Lifecycle and remaining agents (depends on Tier 2 -- Steps 4, 6, 9 require prior SKILL.md changes)
+
+Step 4 modifies design-pipeline SKILL.md after Step 3 has removed old state docs. Step 6 modifies debate-moderator SKILL.md (independent file). Step 9 modifies design-pipeline SKILL.md after Step 4. Steps 4 and 9 must be serialized (same file), but Step 6 can run in parallel with Step 4.
+
+| Task ID | Step | Title |
+|---------|------|-------|
+| T7 | Step 4 | Add state file lifecycle instructions to SKILL.md |
+| T8 | Step 6 | Add state file write instructions to debate-moderator |
+
+### Tier 4: Stage 6 state file instructions (depends on Tier 3 -- Step 9 requires Step 4)
+
+| Task ID | Step | Title |
+|---------|------|-------|
+| T9 | Step 9 | Add Stage 6 state file write instructions |
+
+### Tier 5: Integration test (depends on all prior tiers)
+
+| Task ID | Step | Title |
+|---------|------|-------|
+| T10 | Step 10 | Integration test -- full state file lifecycle |
+
+---
+
+## Task Assignment Table
+
+| Task ID | Title | Tier | Code Writer | Test Writer | Dependencies | Rationale |
+|---------|-------|------|-------------|-------------|--------------|-----------|
+| T1 | Create pipeline-state.md template | 1 | trainer-writer | vitest-writer | None | Markdown template file is a Claude Code artifact; vitest validates structure |
+| T2 | Clean stale expert-selection references | 1 | trainer-writer | vitest-writer | None | SKILL.md modification is a trainer-writer task; vitest asserts content |
+| T3 | Shed state documentation from SKILL.md | 2 | trainer-writer | vitest-writer | T2 | Same SKILL.md file requires sequential modification after T2 |
+| T4 | Add state file write instructions to questioner | 2 | trainer-writer | vitest-writer | T1 | Questioner SKILL.md is a Claude Code artifact; vitest validates content assertions |
+| T5 | Add state file write instructions to tla-writer | 2 | trainer-writer | vitest-writer | T1 | AGENT.md is a Claude Code artifact; vitest validates content assertions |
+| T6 | Add state file write instructions to implementation-writer | 2 | trainer-writer | vitest-writer | T1 | AGENT.md is a Claude Code artifact; vitest validates content assertions |
+| T7 | Add state file lifecycle instructions to SKILL.md | 3 | trainer-writer | vitest-writer | T1, T3 | SKILL.md modification adding state file lifecycle section; vitest validates presence |
+| T8 | Add state file write instructions to debate-moderator | 3 | trainer-writer | vitest-writer | T1 | Debate-moderator SKILL.md is independent of design-pipeline SKILL.md changes |
+| T9 | Add Stage 6 state file write instructions | 4 | trainer-writer | vitest-writer | T7 | Builds on lifecycle instructions added in T7; same file (SKILL.md) |
+| T10 | Integration test -- full lifecycle | 5 | trainer-writer | vitest-writer | T1-T9 | Cross-cutting integration test validates all agents and the template together |

--- a/docs/pipeline-state.md
+++ b/docs/pipeline-state.md
@@ -1,0 +1,49 @@
+# Pipeline State
+
+## Run Metadata
+
+- **Topic:**
+- **Status:** CLEARED
+- **Started:**
+- **Current Stage:**
+
+## Stage 1 — Questioner
+
+- **Status:**
+- **Artifact:**
+- **Timestamp:**
+
+## Stage 2 — Debate Moderator
+
+- **Status:**
+- **Artifact:**
+- **Timestamp:**
+
+## Stage 3 — TLA+ Specification
+
+- **Status:**
+- **Artifact:**
+- **Timestamp:**
+
+## Stage 4 — Expert Review
+
+- **Status:**
+- **Artifact:**
+- **Timestamp:**
+
+## Stage 5 — Implementation Planning
+
+- **Status:**
+- **Artifact:**
+- **Timestamp:**
+
+## Stage 6 — Pair Programming
+
+- **Status:**
+- **Artifact:**
+- **Timestamp:**
+
+## Git
+
+- **Committed:** no
+- **Halt Reason:**

--- a/docs/questioner-sessions/2026-04-02_global-pipeline-state.md
+++ b/docs/questioner-sessions/2026-04-02_global-pipeline-state.md
@@ -1,0 +1,183 @@
+# Questioner Session -- Global Pipeline State Design
+
+**Date:** 2026-04-02
+**Status:** COMPLETE -- READY FOR DEBATE
+**Branches:** 9 of 10 resolved, 1 skipped (Branch 10)
+
+---
+
+## Purpose
+
+Design a global state file that becomes the single source of truth for live pipeline state, replacing the state documentation currently embedded in design-pipeline's SKILL.md. The SKILL.md would then focus purely on behavioral instructions.
+
+---
+
+## Decision Tree
+
+### Branch 1: Purpose and Relationship to accumulated_context
+
+**Question:** The accumulated_context currently serves as the narrative thread passed between stages. Should the global state file replace accumulated_context entirely, or supplement it?
+
+**Answer:** Keep accumulated_context -- the state file supplements it. Design-pipeline SKILL.md sheds its state documentation (changeFlag description, accumulated context table, stage status tracking) because the global state file becomes the single source of truth for live state. SKILL.md focuses purely on behavioral instructions.
+
+**Decision:** State file = live state truth. SKILL.md = behavioral instructions only. accumulated_context = narrative text still passed to agents.
+
+---
+
+### Branch 2: File Format and Location
+
+**Question:** What format and where should the state file live?
+
+**Answer:** Markdown format. Located at `docs/pipeline-state.md`. Singleton file cleared at the start of each run.
+
+**Decision:** `docs/pipeline-state.md`, markdown, cleared per run.
+
+---
+
+### Branch 3: Session Index Relationship
+
+**Question:** The session index at `docs/design-pipeline-sessions/` currently tracks pipeline runs. How does the state file interact with it?
+
+**Answer:** Kill the session index directory. The state file replaces it. Git history serves as the archive for past runs.
+
+**Decision:** Remove `docs/design-pipeline-sessions/`. State file replaces session tracking. Git history = archive.
+
+---
+
+### Branch 4: Error and Retry Strategy
+
+**Question:** When a stage fails, what does the state file enable -- retry, skip, or manual intervention?
+
+**Answer:** Retry in place, then halt. No skipping stages. If a stage fails, retry it. If retry fails, halt the pipeline. The state file records the failure and the pipeline stops.
+
+**Decision:** Retry in place then halt. No stage skipping.
+
+---
+
+### Branch 5: What Gets Stored
+
+**Question:** What data belongs in the state file -- full stage outputs, summaries, or just status flags?
+
+**Answer:** Variables and paths only. No full output capture. The state file is a variable store (current stage, status, timestamps, file paths to artifacts), not a document store. Stage outputs live in their own artifact files.
+
+**Decision:** Variable store only. No document content. Paths point to artifacts.
+
+---
+
+### Branch 6: Write Ownership
+
+**Question:** Who writes to the state file -- a centralized engine/orchestrator, or the agents themselves?
+
+**Answer:** Any agent can write. Distributed ownership with no centralized gatekeeper. The Bun CLI engine no longer exists, so there is no central coordinator to own writes.
+
+**Decision:** Distributed write access. Any agent updates the state file directly.
+
+---
+
+### Branch 7: Conflict Prevention (Multi-Agent Writes)
+
+**Question:** With distributed writes, how do we prevent agents from stomping on each other's state?
+
+**Answer:** Section-scoped ownership. Each agent identifies itself in its own section of the state file. Touching another agent's section is a bug. The file is partitioned by stage/agent, not by data type.
+
+**Decision:** Section-scoped ownership. Agents write only to their own section. Cross-section writes are bugs.
+
+---
+
+### Branch 8: End-of-Run Handling
+
+**Question:** After a pipeline run completes, what happens to the state file -- archive it, clear it, transform it?
+
+**Answer:** Leave as-is after completion. Git history is the archive. No copy/transform step. The next run clears it (per Branch 2).
+
+**Decision:** Leave in place. Next run clears. Git history archives.
+
+---
+
+### Branch 9: Corruption Handling
+
+**Question:** What happens if the state file becomes corrupted or malformed mid-run?
+
+**Answer:** Not applicable. Sequential agent execution and per-run clearing make corruption a non-concern. Only one agent writes at a time, the format is simple markdown, and the file is cleared at the start of each run. There is no realistic corruption vector.
+
+**Decision:** Not applicable -- sequential execution and per-run clearing make corruption a non-concern.
+
+---
+
+### Branch 10: (Skipped)
+
+Skipped at user's request. Proceeding directly to Phase 3 sign-off.
+
+---
+
+## Phase 3: Sign-Off and Expert Council Briefing
+
+### Design Summary
+
+The global pipeline state is a **markdown file at `docs/pipeline-state.md`** that serves as the **single source of truth for live pipeline state**. It replaces the state documentation currently embedded in `design-pipeline/SKILL.md` and eliminates the `docs/design-pipeline-sessions/` directory.
+
+**Core properties:**
+
+| Property | Decision |
+|---|---|
+| Format | Markdown |
+| Location | `docs/pipeline-state.md` |
+| Lifecycle | Cleared at start of each run; left in place after completion |
+| Content scope | Variables, paths, timestamps, status flags only -- no full outputs |
+| Write model | Distributed -- any agent writes to its own section |
+| Conflict prevention | Section-scoped ownership; cross-section writes are bugs |
+| Error strategy | Retry in place, then halt; no stage skipping |
+| Archival | Git history; no copy/transform step |
+| Corruption handling | Non-concern (sequential execution, simple format, per-run clearing) |
+| Relationship to accumulated_context | Supplements it; does not replace the narrative thread |
+| Relationship to SKILL.md | SKILL.md sheds state docs; focuses on behavioral instructions only |
+
+### Downstream Deliverable
+
+A structured briefing for the debate-moderator to evaluate this design with the expert council.
+
+---
+
+## Expert Council Selection
+
+### Roster (from `.claude/skills/orchestrators/debate-moderator/SKILL.md`)
+
+| Expert | Domain | Participate? | Reason |
+|---|---|---|---|
+| expert-tdd | Test-Driven Development | **YES** | State file needs testable contracts. TDD expert evaluates whether the design supports test-first validation of state transitions. |
+| expert-ddd | Domain-Driven Design | **YES** | Core question: is "pipeline state" a well-modeled domain concept? DDD expert evaluates aggregate boundaries, ubiquitous language, and whether the state file is a proper domain artifact or an anemic data dump. |
+| expert-tla | TLA+ Formal Specification | **YES** | The state file is fundamentally a state machine (stages, transitions, retry/halt). TLA+ expert can verify whether the design's invariants (section-scoped ownership, no stage skipping, retry-then-halt) are formally sound. |
+| expert-edge-cases | Edge Case and Failure Hunting | **YES** | Even though corruption was dismissed, this expert should stress-test that assumption. Also evaluates: what if an agent crashes mid-write? What if git commit fails between runs? What about the clear-on-start race? |
+| expert-continuous-delivery | Continuous Delivery and Deployment | **YES** | The state file lives in the repo and gets committed. CD expert evaluates: does this pollute git history? Does clearing per run create noisy diffs? Is there a better lifecycle for CI/CD integration? |
+| expert-bdd | Behavior-Driven Development | **SIT OUT** | No user-facing behavior to describe. This is internal infrastructure state, not observable UI or API behavior. BDD scenarios would be forced and unnatural here. |
+| expert-atomic-design | Atomic / Component-Driven UI Design | **SIT OUT** | No UI components involved. This is a backend/infrastructure concern with no atoms, molecules, or organisms. |
+| expert-performance | Performance Engineering | **SIT OUT** | A single markdown file read/written by one agent at a time has no performance concerns worth debating. |
+| expert-lodash | Lodash Utility Library | **SIT OUT** | No data transformation or collection manipulation to evaluate. The state file design is structural, not algorithmic. |
+
+### Selected Experts (5 of 9)
+
+1. **expert-tdd** -- testability of state contracts
+2. **expert-ddd** -- domain modeling of pipeline state
+3. **expert-tla** -- formal verification of state invariants
+4. **expert-edge-cases** -- stress-testing assumptions (especially Branch 9)
+5. **expert-continuous-delivery** -- git lifecycle and CI/CD integration
+
+---
+
+## Debate Briefing (for debate-moderator)
+
+**Topic:** Global Pipeline State File Design
+
+**Context:** The design-pipeline skill orchestrates a 6-stage sequential pipeline for feature development. Currently, state is scattered across SKILL.md documentation and a session index directory. This proposal consolidates live state into a single markdown file (`docs/pipeline-state.md`) with distributed agent writes, section-scoped ownership, and a clear-per-run lifecycle. The questioner session above documents all 9 resolved design decisions.
+
+**Key tensions for the council to evaluate:**
+
+1. **Distributed writes with section-scoped ownership** -- Is "touching another section is a bug" enforceable, or does it need a runtime guard?
+2. **Git history as archive** -- Is committing a cleared-and-rebuilt state file every run acceptable git hygiene, or does it create noise?
+3. **Variables-only content model** -- Is there a risk that agents will need to store richer state than paths and flags, forcing a future redesign?
+4. **Corruption dismissed as non-concern** -- Is this justified given sequential execution, or are there edge cases (agent crash, partial write) that deserve a guard?
+5. **Session index elimination** -- Does git history truly replace the queryability that a session index provided?
+
+6. **Stale expert-selection references in design-pipeline SKILL.md** -- PR #40 moved expert selection from the questioner to the debate-moderator's autonomous `selectExperts(topic)`. But the design-pipeline SKILL.md still instructs the questioner to include an "Expert Council" section and passes an expert list from Stage 1 to Stages 2 and 4. These stale references must be fixed as part of this pipeline run.
+
+**Experts:** (selected autonomously by debate-moderator)

--- a/docs/tla-specs/global-pipeline-state/GlobalPipelineState.tla
+++ b/docs/tla-specs/global-pipeline-state/GlobalPipelineState.tla
@@ -1,0 +1,327 @@
+-------------------- MODULE GlobalPipelineState --------------------
+\* TLA+ Specification for the Global Pipeline State File
+\* Models three concerns:
+\*   Machine 1 — StateFileLifecycle: ABSENT -> CLEARED -> ACCUMULATING ->
+\*               COMPLETE_SNAPSHOT / HALTED_SNAPSHOT
+\*   Machine 2 — SectionOwnership: per-stage StageResult sections with
+\*               exclusive write ownership
+\*   Machine 3 — GitCommitProtocol: terminal-state-only commits and
+\*               uncommitted-change warning before clearing
+\*
+\* Source: docs/questioner-sessions/2026-04-02_global-pipeline-state.md
+\* Debate:  docs/debate-moderator-sessions/2026-04-02_global-pipeline-state-design.md
+
+EXTENDS Integers, Sequences, FiniteSets, TLC
+
+CONSTANTS
+    NumStages,          \* Total pipeline stages (6 in production)
+    MaxRuns             \* Bound on pipeline runs for finite model checking
+
+ASSUME NumStages >= 1
+ASSUME MaxRuns >= 1
+
+Stages == 1..NumStages
+
+---------------------------------------------------------------------------
+\* State Space Enumerations
+---------------------------------------------------------------------------
+
+FileStates == {
+    "ABSENT",               \* File does not exist (before first run ever)
+    "CLEARED",              \* Template written, all sections empty
+    "ACCUMULATING",         \* At least one stage has written its section
+    "COMPLETE_SNAPSHOT",    \* Pipeline reached COMPLETE
+    "HALTED_SNAPSHOT"       \* Pipeline reached HALTED
+}
+
+SectionStates == {
+    "EMPTY",        \* Section header present but no content (template)
+    "WRITTEN",      \* Section populated by its owning stage
+    "VALIDATED"     \* Section validated by next stage before writing
+}
+
+GitStates == {
+    "CLEAN",            \* No uncommitted changes to state file
+    "DIRTY",            \* State file has uncommitted changes
+    "COMMITTED"         \* Terminal state committed to git
+}
+
+---------------------------------------------------------------------------
+\* Variables
+---------------------------------------------------------------------------
+
+VARIABLES
+    fileState,          \* Current lifecycle state of the state file
+    sections,           \* Function: stage -> section state
+    writtenBy,          \* Function: stage -> which stage wrote it (0 = none)
+    currentStage,       \* Current stage being executed (0 = no run active)
+    runCount,           \* Number of completed pipeline runs
+    gitState,           \* Git status of the state file
+    warned,             \* Whether uncommitted-change warning was issued
+    clearFailed,        \* Whether the clear operation failed
+    halted              \* Whether current run halted (vs completed)
+
+vars == <<fileState, sections, writtenBy, currentStage, runCount,
+          gitState, warned, clearFailed, halted>>
+
+---------------------------------------------------------------------------
+\* Type Invariant
+---------------------------------------------------------------------------
+
+TypeOK ==
+    /\ fileState \in FileStates
+    /\ sections \in [Stages -> SectionStates]
+    /\ writtenBy \in [Stages -> 0..NumStages]
+    /\ currentStage \in 0..NumStages
+    /\ runCount \in 0..MaxRuns
+    /\ gitState \in GitStates
+    /\ warned \in BOOLEAN
+    /\ clearFailed \in BOOLEAN
+    /\ halted \in BOOLEAN
+
+---------------------------------------------------------------------------
+\* Initial State
+---------------------------------------------------------------------------
+
+Init ==
+    /\ fileState = "ABSENT"
+    /\ sections = [s \in Stages |-> "EMPTY"]
+    /\ writtenBy = [s \in Stages |-> 0]
+    /\ currentStage = 0
+    /\ runCount = 0
+    /\ gitState = "CLEAN"
+    /\ warned = FALSE
+    /\ clearFailed = FALSE
+    /\ halted = FALSE
+
+---------------------------------------------------------------------------
+\* Machine 1 — StateFileLifecycle Actions
+---------------------------------------------------------------------------
+
+\* Attempt to clear the state file at the start of a new run.
+\* Preconditions: file is ABSENT, COMPLETE_SNAPSHOT, or HALTED_SNAPSHOT.
+\* The clear can succeed or fail (non-deterministic for model checking).
+ClearStateFile ==
+    /\ fileState \in {"ABSENT", "COMPLETE_SNAPSHOT", "HALTED_SNAPSHOT"}
+    /\ runCount < MaxRuns
+    /\ clearFailed = FALSE
+    \* If dirty, warning must have been issued first
+    /\ gitState /= "DIRTY" \/ warned = TRUE
+    /\ \E success \in BOOLEAN :
+        IF success
+        THEN
+            /\ fileState' = "CLEARED"
+            /\ sections' = [s \in Stages |-> "EMPTY"]
+            /\ writtenBy' = [s \in Stages |-> 0]
+            /\ currentStage' = 0
+            /\ halted' = FALSE
+            /\ clearFailed' = FALSE
+            /\ gitState' = "DIRTY"
+            /\ warned' = FALSE
+            /\ UNCHANGED <<runCount>>
+        ELSE
+            /\ clearFailed' = TRUE
+            /\ UNCHANGED <<fileState, sections, writtenBy, currentStage,
+                           runCount, gitState, warned, halted>>
+
+\* Start the pipeline run after successful clearing.
+\* Transitions CLEARED -> ACCUMULATING by starting Stage 1.
+StartRun ==
+    /\ fileState = "CLEARED"
+    /\ clearFailed = FALSE
+    /\ currentStage = 0
+    /\ currentStage' = 1
+    /\ UNCHANGED <<fileState, sections, writtenBy, runCount,
+                   gitState, warned, clearFailed, halted>>
+
+\* A stage writes its own StageResult section.
+\* Machine 2 invariants enforce ownership.
+WriteStageResult(stage) ==
+    /\ fileState \in {"CLEARED", "ACCUMULATING"}
+    /\ currentStage = stage
+    /\ stage \in Stages
+    /\ sections[stage] = "EMPTY"
+    \* NoStageSkip: stage 1 can always write; stage N requires N-1 written
+    \* SchemaValidation: validate prior sections are well-formed
+    /\ \A s \in 1..(stage - 1) : sections[s] \in {"WRITTEN", "VALIDATED"}
+    /\ sections' = [sections EXCEPT ![stage] = "WRITTEN"]
+    /\ writtenBy' = [writtenBy EXCEPT ![stage] = stage]
+    /\ fileState' = "ACCUMULATING"
+    /\ gitState' = "DIRTY"
+    /\ UNCHANGED <<currentStage, runCount, warned, clearFailed, halted>>
+
+\* Validate a prior stage's section before writing the next one.
+\* This models the schema validation check each stage performs.
+ValidateSection(stage) ==
+    /\ stage \in Stages
+    /\ sections[stage] = "WRITTEN"
+    /\ currentStage > stage
+    /\ sections' = [sections EXCEPT ![stage] = "VALIDATED"]
+    /\ UNCHANGED <<fileState, writtenBy, currentStage, runCount,
+                   gitState, warned, clearFailed, halted>>
+
+\* Advance to the next stage after the current stage writes.
+AdvanceStage ==
+    /\ currentStage \in 1..(NumStages - 1)
+    /\ sections[currentStage] = "WRITTEN"
+    /\ currentStage' = currentStage + 1
+    /\ UNCHANGED <<fileState, sections, writtenBy, runCount,
+                   gitState, warned, clearFailed, halted>>
+
+\* Pipeline completes successfully (all stages written).
+CompletePipeline ==
+    /\ fileState = "ACCUMULATING"
+    /\ currentStage = NumStages
+    /\ sections[NumStages] \in {"WRITTEN", "VALIDATED"}
+    /\ halted = FALSE
+    /\ fileState' = "COMPLETE_SNAPSHOT"
+    /\ runCount' = runCount + 1
+    /\ currentStage' = 0
+    /\ UNCHANGED <<sections, writtenBy, gitState, warned,
+                   clearFailed, halted>>
+
+\* Pipeline halts due to failure (retry exhausted).
+HaltPipeline ==
+    /\ fileState \in {"CLEARED", "ACCUMULATING"}
+    /\ currentStage >= 1
+    /\ halted' = TRUE
+    /\ fileState' = "HALTED_SNAPSHOT"
+    /\ runCount' = runCount + 1
+    /\ currentStage' = 0
+    /\ UNCHANGED <<sections, writtenBy, gitState, warned, clearFailed>>
+
+---------------------------------------------------------------------------
+\* Machine 3 — GitCommitProtocol Actions
+---------------------------------------------------------------------------
+
+\* Warn about uncommitted changes before clearing.
+WarnUncommitted ==
+    /\ gitState = "DIRTY"
+    /\ warned = FALSE
+    /\ warned' = TRUE
+    /\ UNCHANGED <<fileState, sections, writtenBy, currentStage,
+                   runCount, gitState, clearFailed, halted>>
+
+\* Commit state file — only allowed at terminal states.
+CommitStateFile ==
+    /\ fileState \in {"COMPLETE_SNAPSHOT", "HALTED_SNAPSHOT"}
+    /\ gitState = "DIRTY"
+    /\ gitState' = "COMMITTED"
+    /\ UNCHANGED <<fileState, sections, writtenBy, currentStage,
+                   runCount, warned, clearFailed, halted>>
+
+---------------------------------------------------------------------------
+\* Next State Relation
+---------------------------------------------------------------------------
+
+Next ==
+    \/ ClearStateFile
+    \/ StartRun
+    \/ \E s \in Stages : WriteStageResult(s)
+    \/ \E s \in Stages : ValidateSection(s)
+    \/ AdvanceStage
+    \/ CompletePipeline
+    \/ HaltPipeline
+    \/ WarnUncommitted
+    \/ CommitStateFile
+
+Fairness ==
+    /\ WF_vars(ClearStateFile)
+    /\ WF_vars(StartRun)
+    /\ \A s \in Stages : WF_vars(WriteStageResult(s))
+    /\ WF_vars(AdvanceStage)
+    /\ WF_vars(CompletePipeline)
+    /\ WF_vars(HaltPipeline)
+    /\ WF_vars(WarnUncommitted)
+    /\ WF_vars(CommitStateFile)
+
+Spec == Init /\ [][Next]_vars /\ Fairness
+
+---------------------------------------------------------------------------
+\* Machine 2 — SectionOwnership Safety Properties
+---------------------------------------------------------------------------
+
+\* SectionOwnership: each stage's section is written only by its owner.
+\* writtenBy[s] is either 0 (not written) or s (written by owner).
+SectionOwnership ==
+    \A s \in Stages : writtenBy[s] \in {0, s}
+
+\* NoStageSkip: stage N is written only if all stages 1..(N-1) are written.
+NoStageSkip ==
+    \A s \in Stages :
+        sections[s] \in {"WRITTEN", "VALIDATED"} =>
+            \A p \in 1..(s - 1) : sections[p] \in {"WRITTEN", "VALIDATED"}
+
+---------------------------------------------------------------------------
+\* Machine 1 — StateFileLifecycle Safety Properties
+---------------------------------------------------------------------------
+
+\* ClearOnStart: no run begins with stale data.
+\* If currentStage >= 1 (run active), the file was cleared this run.
+\* Specifically: all sections not yet written are EMPTY.
+ClearOnStart ==
+    currentStage >= 1 =>
+        \A s \in (currentStage + 1)..NumStages : sections[s] = "EMPTY"
+
+\* FailFastOnClearFailure: if clear failed, pipeline does not start.
+FailFastOnClearFailure ==
+    clearFailed = TRUE => currentStage = 0
+
+\* SchemaValidation: when a stage writes, all prior stages are populated.
+\* (This is enforced by the guard in WriteStageResult but we verify it
+\*  as an invariant on the reachable state space.)
+SchemaValidationInvariant ==
+    \A s \in Stages :
+        sections[s] \in {"WRITTEN", "VALIDATED"} =>
+            \A p \in 1..(s - 1) : sections[p] \in {"WRITTEN", "VALIDATED"}
+
+\* ClearedSectionsEmpty: when the file is CLEARED, every section is EMPTY.
+\* Documents the meaning of CLEARED — the template has been written but
+\* no stage has populated its section yet.
+ClearedSectionsEmpty ==
+    fileState = "CLEARED" => \A s \in Stages : sections[s] = "EMPTY"
+
+\* HaltedConsistency: the halted boolean and HALTED_SNAPSHOT file state
+\* are always in agreement. The boolean is redundant but aids readability;
+\* this invariant prevents them from diverging.
+HaltedConsistency ==
+    halted = TRUE <=> fileState = "HALTED_SNAPSHOT"
+
+---------------------------------------------------------------------------
+\* Machine 3 — GitCommitProtocol Safety Properties
+---------------------------------------------------------------------------
+
+\* TerminalStateOnlyCommit: the state file is only committed at
+\* COMPLETE_SNAPSHOT or HALTED_SNAPSHOT.
+TerminalStateOnlyCommit ==
+    gitState = "COMMITTED" =>
+        fileState \in {"COMPLETE_SNAPSHOT", "HALTED_SNAPSHOT"}
+
+\* UncommittedWarningBeforeClear: if the file has uncommitted changes
+\* and we attempt to clear, a warning must be issued first.
+\* (Enforced by ClearStateFile guard: gitState /= "DIRTY" \/ warned = TRUE.)
+\* After clearing, gitState becomes DIRTY (template write) and warned
+\* resets to FALSE — that is expected. The invariant we verify on
+\* reachable states: warned is only TRUE when gitState is DIRTY or
+\* COMMITTED (warning persists through commit since commit doesn't
+\* reset it; clearing resets both warned and gitState).
+UncommittedWarningProtocol ==
+    warned = TRUE => gitState \in {"DIRTY", "COMMITTED"}
+
+---------------------------------------------------------------------------
+\* Liveness Properties
+---------------------------------------------------------------------------
+
+\* Progress: if a pipeline run starts (CLEARED), it eventually reaches
+\* COMPLETE_SNAPSHOT or HALTED_SNAPSHOT.
+Progress ==
+    fileState = "CLEARED" ~>
+        fileState \in {"COMPLETE_SNAPSHOT", "HALTED_SNAPSHOT"}
+
+\* EventualCommit: if the file reaches a terminal state, it is eventually
+\* committed (assuming the user acts on the warning).
+EventualCommit ==
+    fileState \in {"COMPLETE_SNAPSHOT", "HALTED_SNAPSHOT"} ~>
+        gitState \in {"COMMITTED", "CLEAN"}
+
+=====================================================================

--- a/docs/tla-specs/global-pipeline-state/MC.cfg
+++ b/docs/tla-specs/global-pipeline-state/MC.cfg
@@ -1,0 +1,21 @@
+SPECIFICATION Spec
+
+CHECK_DEADLOCK FALSE
+
+CONSTANT
+    NumStages = 4
+    MaxRuns = 2
+
+INVARIANT TypeOK
+INVARIANT SectionOwnership
+INVARIANT NoStageSkip
+INVARIANT ClearOnStart
+INVARIANT FailFastOnClearFailure
+INVARIANT SchemaValidationInvariant
+INVARIANT TerminalStateOnlyCommit
+INVARIANT UncommittedWarningProtocol
+INVARIANT ClearedSectionsEmpty
+INVARIANT HaltedConsistency
+
+PROPERTY Progress
+PROPERTY EventualCommit

--- a/docs/tla-specs/global-pipeline-state/MC.tla
+++ b/docs/tla-specs/global-pipeline-state/MC.tla
@@ -1,0 +1,6 @@
+------------------------------- MODULE MC -------------------------------
+\* Model checking module — provides concrete constant values
+
+EXTENDS GlobalPipelineState, TLC
+
+=============================================================================

--- a/docs/tla-specs/global-pipeline-state/MC_Full.cfg
+++ b/docs/tla-specs/global-pipeline-state/MC_Full.cfg
@@ -1,0 +1,21 @@
+SPECIFICATION Spec
+
+CHECK_DEADLOCK FALSE
+
+CONSTANT
+    NumStages = 6
+    MaxRuns = 2
+
+INVARIANT TypeOK
+INVARIANT SectionOwnership
+INVARIANT NoStageSkip
+INVARIANT ClearOnStart
+INVARIANT FailFastOnClearFailure
+INVARIANT SchemaValidationInvariant
+INVARIANT TerminalStateOnlyCommit
+INVARIANT UncommittedWarningProtocol
+INVARIANT ClearedSectionsEmpty
+INVARIANT HaltedConsistency
+
+PROPERTY Progress
+PROPERTY EventualCommit

--- a/docs/tla-specs/global-pipeline-state/README.md
+++ b/docs/tla-specs/global-pipeline-state/README.md
@@ -1,0 +1,78 @@
+# TLA+ Specification: Global Pipeline State File
+
+## Source
+Briefing: `docs/questioner-sessions/2026-04-02_global-pipeline-state.md`
+Debate (design): `docs/debate-moderator-sessions/2026-04-02_global-pipeline-state-design.md`
+Debate (TLA+ review): `docs/debate-moderator-sessions/2026-04-02_global-pipeline-state-tla-review.md`
+
+## Specification
+- **Module:** `GlobalPipelineState.tla`
+- **Config (small):** `MC.cfg` (4 stages, 2 runs)
+- **Config (production):** `MC_Full.cfg` (6 stages, 2 runs)
+- **Model checking module:** `MC.tla`
+
+## States
+
+### File Lifecycle (Machine 1)
+- **ABSENT** — file does not exist (before first pipeline run)
+- **CLEARED** — template written with section headers and empty values
+- **ACCUMULATING** — at least one stage has written its StageResult
+- **COMPLETE_SNAPSHOT** — pipeline completed successfully
+- **HALTED_SNAPSHOT** — pipeline halted due to failure
+
+### Section States (Machine 2)
+- **EMPTY** — section header present, no content
+- **WRITTEN** — populated by owning stage
+- **VALIDATED** — validated by a subsequent stage before writing
+
+### Git States (Machine 3)
+- **CLEAN** — no uncommitted changes
+- **DIRTY** — state file has uncommitted changes
+- **COMMITTED** — terminal state committed to git
+
+## Properties Verified
+
+### Safety (10 Invariants)
+- **TypeOK** — all variables remain within their declared domains
+- **SectionOwnership** — each stage's section is written only by its owning stage (writtenBy[s] is 0 or s)
+- **NoStageSkip** — stage N is written only after all stages 1..(N-1) are written
+- **ClearOnStart** — when a run is active, all unwritten sections are EMPTY (no stale data)
+- **FailFastOnClearFailure** — if the clear operation fails, the pipeline does not start
+- **SchemaValidationInvariant** — when a stage writes, all prior stages are populated
+- **TerminalStateOnlyCommit** — state file is committed only at COMPLETE_SNAPSHOT or HALTED_SNAPSHOT
+- **UncommittedWarningProtocol** — warned is only TRUE when gitState is DIRTY or COMMITTED (warning must precede clearing)
+- **ClearedSectionsEmpty** — when fileState is CLEARED, every section is EMPTY (documents the meaning of the CLEARED state)
+- **HaltedConsistency** — `halted = TRUE` if and only if `fileState = "HALTED_SNAPSHOT"` (prevents the redundant boolean from diverging)
+
+### Liveness
+- **Progress** — if a pipeline run starts (CLEARED), it eventually reaches COMPLETE_SNAPSHOT or HALTED_SNAPSHOT
+- **EventualCommit** — if the file reaches a terminal state, it is eventually committed
+
+## Design Decisions
+
+### MaxRuns = 2 is sufficient
+`ClearStateFile` resets all state variables (sections, writtenBy, currentStage, halted, warned) to their initial values. The system is memoryless between runs — no state carries over from run N to run N+1 except `runCount`, `fileState`, and `gitState`. Two runs are enough to exercise the full clear-then-run cycle including the second run's interaction with prior git state (DIRTY/COMMITTED/CLEAN from the first run).
+
+### clearFailed = TRUE is an intentional deadlock
+When `ClearStateFile` fails non-deterministically, `clearFailed` is set to TRUE and no further actions are enabled (the pipeline cannot start, and no action resets `clearFailed`). This models a **fail-fast** design: if the state file cannot be cleared, the pipeline stops immediately and requires human intervention. TLC's `CHECK_DEADLOCK FALSE` setting acknowledges this as intentional.
+
+## TLC Results
+
+### Small model (4 stages, 2 runs)
+- **States generated:** 910
+- **Distinct states:** 467
+- **Depth:** 20
+- **Result:** PASS (10 invariants, 2 liveness properties)
+- **Workers:** 4
+
+### Production model (6 stages, 2 runs)
+- **States generated:** 4,206
+- **Distinct states:** 1,907
+- **Depth:** 26
+- **Result:** PASS (10 invariants, 2 liveness properties)
+- **Workers:** 4
+
+- **Date:** 2026-04-02 (v2 — post-review revision)
+
+## Prior Versions
+None (v1 was same directory, superseded by review feedback)

--- a/next-task.md
+++ b/next-task.md
@@ -1,5 +1,0 @@
-1. questioner should no longer recommend and confirm which experts debate, instead the debate moderator will choose without user input
-   1. if the debate moderator feels there is a expert missing that would be valued, they make a note of it in docs/user_notes.md, this should be a single file that is apppended to with various requests
-2. Similarly, the implantation writer should be able to add requests for other writers in the same file
-3. Along with this, a lodash expert should be created
-4. Create a puml diagram of the design pipeline in the repo root

--- a/packages/design-pipeline/package.json
+++ b/packages/design-pipeline/package.json
@@ -1,5 +1,8 @@
 {
   "author": "Ethan Glover",
+  "bin": {
+    "pipeline-runner": "./src/bin.ts"
+  },
   "dependencies": {
     "lodash": "^4.18.1",
     "zod": "^4.3.6"
@@ -12,9 +15,6 @@
     "typescript": "^6.0.2",
     "vite": "^8.0.3",
     "vitest": "^4.1.2"
-  },
-  "bin": {
-    "pipeline-runner": "./src/bin.ts"
   },
   "exports": {
     "./*": "./src/*"

--- a/packages/design-pipeline/src/skill-tests/debate-moderator-state-write.test.ts
+++ b/packages/design-pipeline/src/skill-tests/debate-moderator-state-write.test.ts
@@ -1,0 +1,68 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const SKILL_PATH = path.join(
+  import.meta.dirname,
+  "..",
+  "..",
+  "..",
+  "..",
+  ".claude",
+  "skills",
+  "orchestrators",
+  "debate-moderator",
+  "SKILL.md",
+);
+
+const content = readFileSync(SKILL_PATH, "utf8");
+
+const PIPELINE_STATE_FILE = "pipeline-state.md";
+const STAGE_2 = "Stage 2";
+const STAGE_4 = "Stage 4";
+
+describe("debate-moderator SKILL.md — pipeline state file instructions", () => {
+  it("references the pipeline state file", () => {
+    expect(content).toContain(PIPELINE_STATE_FILE);
+  });
+
+  it("contains instructions about writing Stage 2 and Stage 4 StageResult sections", () => {
+    expect(content).toContain(STAGE_2);
+    expect(content).toContain(STAGE_4);
+    expect(content).toMatch(/stage 2.*stageresult|stageresult.*stage 2/iu);
+    expect(content).toMatch(/stage 4.*stageresult|stageresult.*stage 4/iu);
+  });
+
+  it("contains instructions about validating prior stages before writing", () => {
+    expect(content).toMatch(/for stage 2.*stage 1/iu);
+    expect(content).toMatch(/for stage 4/iu);
+    expect(content).toMatch(/stages 1, 2, and 3/iu);
+  });
+
+  it("describes conditional detection for pipeline runs via ACCUMULATING status", () => {
+    expect(content).toContain("ACCUMULATING");
+  });
+
+  it("instructs writing only to the assigned stage section (section-scoped ownership)", () => {
+    expect(content).toMatch(
+      /only.*assigned.*stage|section.scoped|do not modify.*other/iu,
+    );
+  });
+
+  it("includes Status, Artifact, and Timestamp fields", () => {
+    const pipelineSection = content.slice(content.indexOf(PIPELINE_STATE_FILE));
+
+    expect(pipelineSection).toMatch(/\*\*Status:\*\*/u);
+    expect(pipelineSection).toMatch(/\*\*Artifact:\*\*/u);
+    expect(pipelineSection).toMatch(/\*\*Timestamp:\*\*/u);
+  });
+
+  it("mentions CONSENSUS REACHED and PARTIAL CONSENSUS as possible status values", () => {
+    expect(content).toContain("CONSENSUS REACHED");
+    expect(content).toContain("PARTIAL CONSENSUS");
+  });
+
+  it("reports validation failure to the caller when prior stages are missing", () => {
+    expect(content).toMatch(/report.*error.*caller|error.*caller/iu);
+  });
+});

--- a/packages/design-pipeline/src/skill-tests/expert-lodash.test.ts
+++ b/packages/design-pipeline/src/skill-tests/expert-lodash.test.ts
@@ -15,7 +15,7 @@ const SKILL_PATH = path.join(
   "SKILL.md",
 );
 
-const content = readFileSync(SKILL_PATH, "utf8");
+const content = readFileSync(SKILL_PATH, "utf8").replaceAll("\r\n", "\n");
 
 const frontmatterMatch = /^---\r?\n([\S\s]*?)\r?\n---/u.exec(content);
 const frontmatter = frontmatterMatch?.[1] ?? "";

--- a/packages/design-pipeline/src/skill-tests/expert-selection-cleanup.test.ts
+++ b/packages/design-pipeline/src/skill-tests/expert-selection-cleanup.test.ts
@@ -1,0 +1,53 @@
+import find from "lodash/find.js";
+import includes from "lodash/includes.js";
+import split from "lodash/split.js";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const SKILL_PATH = path.join(
+  __dirname,
+  "..",
+  "..",
+  "..",
+  "..",
+  ".claude",
+  "skills",
+  "design-pipeline",
+  "SKILL.md",
+);
+
+const content = readFileSync(SKILL_PATH, "utf8");
+
+describe("design-pipeline SKILL.md — expert-selection cleanup", () => {
+  it("does NOT contain 'Expert Council' (case-sensitive)", () => {
+    expect(content).not.toContain("Expert Council");
+  });
+
+  it("does NOT contain 'expert list' in accumulated context or stage input descriptions", () => {
+    expect(content).not.toContain("expert list");
+  });
+
+  it("Stage 1 diagram label does NOT contain 'expert selection'", () => {
+    const stage1DiagramLine = find(split(content, "\n"), (line) => {
+      return includes(line, "Stage 1: Questioner") && includes(line, "───");
+    });
+
+    expect(stage1DiagramLine).toBeDefined();
+    expect(stage1DiagramLine).not.toMatch(/expert selection/iu);
+  });
+
+  it("does NOT contain the constraint 'Expert selection from Stage 1 is reused'", () => {
+    expect(content).not.toContain("Expert selection from Stage 1 is reused");
+  });
+
+  it("Stages 2 and 4 input sections do NOT reference expert list from Stage 1", () => {
+    expect(content).not.toContain("The expert list confirmed in Stage 1");
+    expect(content).not.toContain("The same expert list from Stage 1");
+  });
+
+  it("still contains 'Stage 1' and 'Questioner' (Stage 1 itself is preserved)", () => {
+    expect(content).toContain("Stage 1");
+    expect(content).toContain("Questioner");
+  });
+});

--- a/packages/design-pipeline/src/skill-tests/impl-writer-state-write.test.ts
+++ b/packages/design-pipeline/src/skill-tests/impl-writer-state-write.test.ts
@@ -1,0 +1,58 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const AGENT_PATH = path.join(
+  import.meta.dirname,
+  "..",
+  "..",
+  "..",
+  "..",
+  ".claude",
+  "skills",
+  "implementation-writer",
+  "AGENT.md",
+);
+
+const content = readFileSync(AGENT_PATH, "utf8");
+
+const PIPELINE_STATE_FILE = "pipeline-state.md";
+const STAGE_5 = "Stage 5";
+
+describe("implementation-writer AGENT.md — pipeline state file instructions", () => {
+  it("references the pipeline state file", () => {
+    expect(content).toContain(PIPELINE_STATE_FILE);
+  });
+
+  it("contains instructions about writing a Stage 5 StageResult section", () => {
+    expect(content).toContain(STAGE_5);
+    expect(content).toMatch(/stage 5.*stageresult/iu);
+  });
+
+  it("contains instructions about validating prior stages before writing", () => {
+    expect(content).toMatch(/stage 1/iu);
+    expect(content).toMatch(/stage 2/iu);
+    expect(content).toMatch(/stage 3/iu);
+    expect(content).toMatch(/stage 4/iu);
+    expect(content).toMatch(/validat|check|verify|populated|present/iu);
+  });
+
+  it("describes the conditional detection for pipeline runs via ACCUMULATING status", () => {
+    expect(content).toContain("ACCUMULATING");
+  });
+
+  it("instructs writing only to the Stage 5 section (section-scoped ownership)", () => {
+    expect(content).toMatch(/only.*stage 5|stage 5.*only|section.scoped/iu);
+  });
+
+  it("includes Status, Artifact, and Timestamp fields in the Stage 5 output", () => {
+    const pipelineSection = content.slice(content.indexOf(PIPELINE_STATE_FILE));
+    expect(pipelineSection).toMatch(/status/iu);
+    expect(pipelineSection).toMatch(/artifact/iu);
+    expect(pipelineSection).toMatch(/timestamp/iu);
+  });
+
+  it("specifies COMPLETE as the status value", () => {
+    expect(content).toContain("COMPLETE");
+  });
+});

--- a/packages/design-pipeline/src/skill-tests/pipeline-state-integration.test.ts
+++ b/packages/design-pipeline/src/skill-tests/pipeline-state-integration.test.ts
@@ -1,0 +1,219 @@
+import every from "lodash/every.js";
+import filter from "lodash/filter.js";
+import includes from "lodash/includes.js";
+import some from "lodash/some.js";
+import split from "lodash/split.js";
+import values from "lodash/values.js";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const MONOREPO_ROOT = path.join(import.meta.dirname, "..", "..", "..", "..");
+
+const PIPELINE_STATE_REF = "pipeline-state.md";
+const PIPELINE_STATE_SHORT = "pipeline-state";
+const SESSION_DIR_REF = "design-pipeline-sessions";
+
+const AGENT_FILES = {
+  debateModerator: path.join(
+    MONOREPO_ROOT,
+    ".claude",
+    "skills",
+    "orchestrators",
+    "debate-moderator",
+    "SKILL.md",
+  ),
+  designPipeline: path.join(
+    MONOREPO_ROOT,
+    ".claude",
+    "skills",
+    "design-pipeline",
+    "SKILL.md",
+  ),
+  implementationWriter: path.join(
+    MONOREPO_ROOT,
+    ".claude",
+    "skills",
+    "implementation-writer",
+    "AGENT.md",
+  ),
+  questioner: path.join(
+    MONOREPO_ROOT,
+    ".claude",
+    "skills",
+    "questioner",
+    "SKILL.md",
+  ),
+  tlaWriter: path.join(
+    MONOREPO_ROOT,
+    ".claude",
+    "skills",
+    "tla-writer",
+    "AGENT.md",
+  ),
+} as const;
+
+const TEMPLATE_PATH = path.join(MONOREPO_ROOT, "docs", "pipeline-state.md");
+
+const contents = {
+  debateModerator: readFileSync(AGENT_FILES.debateModerator, "utf8"),
+  designPipeline: readFileSync(AGENT_FILES.designPipeline, "utf8"),
+  implementationWriter: readFileSync(AGENT_FILES.implementationWriter, "utf8"),
+  questioner: readFileSync(AGENT_FILES.questioner, "utf8"),
+  tlaWriter: readFileSync(AGENT_FILES.tlaWriter, "utf8"),
+};
+
+const allContents = values(contents);
+
+const templateContent = readFileSync(TEMPLATE_PATH, "utf8").replaceAll(
+  "\r\n",
+  "\n",
+);
+
+describe("pipeline state integration — cross-file coherence", () => {
+  it("all 5 agent/skill files reference pipeline-state.md", () => {
+    const allReference = every(allContents, (content) => {
+      return includes(content, PIPELINE_STATE_REF);
+    });
+
+    expect(allReference).toBe(true);
+  });
+
+  describe("stage number coverage — each agent owns its stage writes", () => {
+    it("questioner mentions Stage 1 in context of state file writes", () => {
+      expect(contents.questioner).toMatch(/Stage 1/u);
+
+      const lines = split(contents.questioner, "\n");
+      const hasStage1Write = some(lines, (line) => {
+        return (
+          includes(line, "Stage 1") && includes(line, PIPELINE_STATE_SHORT)
+        );
+      });
+
+      expect(hasStage1Write).toBe(true);
+    });
+
+    it("debate-moderator mentions Stage 2 and Stage 4 in context of state file writes", () => {
+      const lines = split(contents.debateModerator, "\n");
+
+      const hasStage2 = some(lines, (line) => {
+        return includes(line, "Stage 2");
+      });
+      const hasStage4 = some(lines, (line) => {
+        return includes(line, "Stage 4");
+      });
+
+      expect(hasStage2).toBe(true);
+      expect(hasStage4).toBe(true);
+      expect(contents.debateModerator).toContain(PIPELINE_STATE_REF);
+    });
+
+    it("tla-writer mentions Stage 3 in context of state file writes", () => {
+      expect(contents.tlaWriter).toMatch(/Stage 3/u);
+
+      const lines = split(contents.tlaWriter, "\n");
+      const hasStage3Write = some(lines, (line) => {
+        return (
+          includes(line, "Stage 3") && includes(line, PIPELINE_STATE_SHORT)
+        );
+      });
+
+      expect(hasStage3Write).toBe(true);
+    });
+
+    it("implementation-writer mentions Stage 5 in context of state file writes", () => {
+      expect(contents.implementationWriter).toMatch(/Stage 5/u);
+
+      const lines = split(contents.implementationWriter, "\n");
+      const hasStage5Write = some(lines, (line) => {
+        return (
+          includes(line, "Stage 5") && includes(line, PIPELINE_STATE_SHORT)
+        );
+      });
+
+      expect(hasStage5Write).toBe(true);
+    });
+
+    it("design-pipeline mentions Stage 6 in context of state file writes", () => {
+      expect(contents.designPipeline).toMatch(/Stage 6/u);
+
+      const lines = split(contents.designPipeline, "\n");
+      const hasStage6Write = some(lines, (line) => {
+        return (
+          includes(line, "Stage 6") && includes(line, PIPELINE_STATE_SHORT)
+        );
+      });
+
+      expect(hasStage6Write).toBe(true);
+    });
+  });
+
+  describe("design-pipeline SKILL.md contains lifecycle concepts", () => {
+    it("contains fail-fast for clear failure handling", () => {
+      expect(contents.designPipeline).toContain("fail-fast");
+    });
+
+    it("contains uncommitted as warning before clearing", () => {
+      expect(contents.designPipeline).toMatch(/uncommitted/iu);
+    });
+
+    it("contains terminal in context of commits", () => {
+      const lines = split(contents.designPipeline, "\n");
+      const hasTerminalCommit = some(lines, (line) => {
+        return includes(line, "terminal") && includes(line, "commit");
+      });
+
+      expect(hasTerminalCommit).toBe(true);
+    });
+
+    it("contains section in context of ownership", () => {
+      const hasSectionOwnership =
+        includes(contents.designPipeline, "section ownership") ||
+        includes(contents.designPipeline, "section-scoped ownership") ||
+        includes(contents.designPipeline, "Section-Scoped Ownership") ||
+        includes(contents.designPipeline, "Section Ownership");
+
+      expect(hasSectionOwnership).toBe(true);
+    });
+  });
+
+  it("template file contains exactly 6 stage sections", () => {
+    const stageHeadings = filter(split(templateContent, "\n"), (line) => {
+      return /^## Stage \d/u.test(line);
+    });
+
+    expect(stageHeadings).toHaveLength(6);
+  });
+
+  describe("no stale session index references — docs/design-pipeline-sessions/ eliminated", () => {
+    it("questioner does not reference docs/design-pipeline-sessions/", () => {
+      expect(contents.questioner).not.toContain(SESSION_DIR_REF);
+    });
+
+    it("debate-moderator does not reference docs/design-pipeline-sessions/", () => {
+      expect(contents.debateModerator).not.toContain(SESSION_DIR_REF);
+    });
+
+    it("tla-writer does not reference docs/design-pipeline-sessions/", () => {
+      expect(contents.tlaWriter).not.toContain(SESSION_DIR_REF);
+    });
+
+    it("implementation-writer does not reference docs/design-pipeline-sessions/", () => {
+      expect(contents.implementationWriter).not.toContain(SESSION_DIR_REF);
+    });
+
+    it("design-pipeline does not reference docs/design-pipeline-sessions/", () => {
+      expect(contents.designPipeline).not.toContain(SESSION_DIR_REF);
+    });
+  });
+
+  describe("no stale Expert Council references", () => {
+    it("design-pipeline SKILL.md does not contain Expert Council", () => {
+      expect(contents.designPipeline).not.toContain("Expert Council");
+    });
+
+    it("questioner SKILL.md does not contain Expert Council", () => {
+      expect(contents.questioner).not.toContain("Expert Council");
+    });
+  });
+});

--- a/packages/design-pipeline/src/skill-tests/pipeline-state-template.test.ts
+++ b/packages/design-pipeline/src/skill-tests/pipeline-state-template.test.ts
@@ -1,0 +1,63 @@
+import filter from "lodash/filter.js";
+import split from "lodash/split.js";
+import trim from "lodash/trim.js";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const TEMPLATE_PATH = path.join(
+  import.meta.dirname,
+  "..",
+  "..",
+  "..",
+  "..",
+  "docs",
+  "pipeline-state.md",
+);
+
+const content = readFileSync(TEMPLATE_PATH, "utf8").replaceAll("\r\n", "\n");
+
+const STATUS_FIELD = "**Status:**";
+const ARTIFACT_FIELD = "**Artifact:**";
+const TIMESTAMP_FIELD = "**Timestamp:**";
+
+describe("docs/pipeline-state.md template", () => {
+  it("is not empty", () => {
+    expect(trim(content).length).toBeGreaterThan(0);
+  });
+
+  it("contains exactly 6 stage sections", () => {
+    const stageHeadings = filter(split(content, "\n"), (line) => {
+      return /^## Stage \d/u.test(line);
+    });
+
+    expect(stageHeadings).toHaveLength(6);
+  });
+
+  it("has Stage 1 through Stage 6 headings", () => {
+    for (let index = 1; 6 >= index; index += 1) {
+      expect(content).toContain(`## Stage ${String(index)}`);
+    }
+  });
+
+  it("each stage section contains Status, Artifact, and Timestamp fields", () => {
+    const stages = split(content, /^## Stage \d/mu).slice(1);
+
+    expect(stages).toHaveLength(6);
+
+    for (const stage of stages) {
+      expect(stage).toContain(STATUS_FIELD);
+      expect(stage).toContain(ARTIFACT_FIELD);
+      expect(stage).toContain(TIMESTAMP_FIELD);
+    }
+  });
+
+  it("run-level metadata section has Status set to CLEARED", () => {
+    expect(content).toContain("**Status:** CLEARED");
+  });
+
+  it("Git section exists with Committed set to no", () => {
+    expect(content).toContain("## Git");
+    expect(content).toContain("**Committed:** no");
+  });
+});

--- a/packages/design-pipeline/src/skill-tests/questioner-state-write.test.ts
+++ b/packages/design-pipeline/src/skill-tests/questioner-state-write.test.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const SKILL_PATH = path.join(
+  __dirname,
+  "..",
+  "..",
+  "..",
+  "..",
+  ".claude",
+  "skills",
+  "questioner",
+  "SKILL.md",
+);
+
+const content = readFileSync(SKILL_PATH, "utf8");
+
+const PIPELINE_STATE_FILE = "pipeline-state.md";
+
+describe("questioner SKILL.md — pipeline state file write instructions", () => {
+  it("references the pipeline state file", () => {
+    expect(content).toContain(PIPELINE_STATE_FILE);
+  });
+
+  it("contains instructions to write Stage 1 results to the state file", () => {
+    expect(content).toMatch(/stage 1/iu);
+    expect(content).toMatch(/stageresult|stage.?result|status.*complete/iu);
+  });
+
+  it("includes a condition for pipeline context detection", () => {
+    expect(content).toMatch(
+      /pipeline.run|design.pipeline|pipeline.state\.md.*exists/iu,
+    );
+  });
+
+  it("instructs writing Status, Artifact, and Timestamp fields", () => {
+    expect(content).toMatch(/\*\*Status:\*\*/u);
+    expect(content).toMatch(/\*\*Artifact:\*\*/u);
+    expect(content).toMatch(/\*\*Timestamp:\*\*/u);
+  });
+
+  it("specifies section-scoped ownership — only Stage 1", () => {
+    expect(content).toMatch(
+      /only.*stage 1|do not modify.*other|section.scoped/iu,
+    );
+  });
+
+  it("instructs validating the state file exists before writing", () => {
+    expect(content).toMatch(/validate|verify|check.*exist/iu);
+  });
+
+  it("detects pipeline context via state file status CLEARED or ACCUMULATING", () => {
+    expect(content).toMatch(/CLEARED/u);
+    expect(content).toMatch(/ACCUMULATING/u);
+  });
+});

--- a/packages/design-pipeline/src/skill-tests/stage6-state-write.test.ts
+++ b/packages/design-pipeline/src/skill-tests/stage6-state-write.test.ts
@@ -1,0 +1,85 @@
+import findIndex from "lodash/findIndex.js";
+import includes from "lodash/includes.js";
+import some from "lodash/some.js";
+import split from "lodash/split.js";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const SKILL_PATH = path.join(
+  import.meta.dirname,
+  "..",
+  "..",
+  "..",
+  "..",
+  ".claude",
+  "skills",
+  "design-pipeline",
+  "SKILL.md",
+);
+
+const content = readFileSync(SKILL_PATH, "utf8");
+const lines = split(content, "\n");
+
+const PIPELINE_STATE_FILE = "pipeline-state.md";
+const STAGE_6 = "Stage 6";
+
+describe("design-pipeline SKILL.md — Stage 6 state file write instructions", () => {
+  it("references writing the Stage 6 StageResult in pipeline-state.md", () => {
+    expect(content).toMatch(/stage 6.*stageresult|stageresult.*stage 6/iu);
+    expect(content).toContain(PIPELINE_STATE_FILE);
+  });
+
+  it("references committing the state file in the COMPLETE block", () => {
+    const completeIndex = findIndex(lines, (line) => {
+      return includes(line, "Terminal Artifact") || includes(line, "6g");
+    });
+
+    expect(completeIndex).toBeGreaterThan(-1);
+
+    const completeSlice = lines.slice(completeIndex, completeIndex + 20);
+    const hasCommitKeyword = some(completeSlice, (line) => {
+      return includes(line, "commit") || includes(line, "Commit");
+    });
+    const hasStateFileReference = some(completeSlice, (line) => {
+      return includes(line, "state file") || includes(line, "pipeline-state");
+    });
+
+    expect(hasCommitKeyword).toBe(true);
+    expect(hasStateFileReference).toBe(true);
+  });
+
+  it("references committing the state file in the HALTED handling", () => {
+    const haltedReasonIndex = findIndex(lines, (line) => {
+      return includes(line, "HaltReasonConsistent");
+    });
+
+    expect(haltedReasonIndex).toBeGreaterThan(-1);
+
+    const haltedSlice = lines.slice(haltedReasonIndex, haltedReasonIndex + 15);
+    const hasCommitKeyword = some(haltedSlice, (line) => {
+      return includes(line, "commit") || includes(line, "Commit");
+    });
+    const hasStateFileReference = some(haltedSlice, (line) => {
+      return includes(line, "state file") || includes(line, "pipeline-state");
+    });
+
+    expect(hasCommitKeyword).toBe(true);
+    expect(hasStateFileReference).toBe(true);
+  });
+
+  it("contains instructions about validating prior stages (1-5) before writing", () => {
+    const stage6StateIndex = findIndex(lines, (line) => {
+      return includes(line, STAGE_6) && includes(line, "State File");
+    });
+
+    expect(stage6StateIndex).toBeGreaterThan(-1);
+
+    const stage6Slice = lines.slice(stage6StateIndex, stage6StateIndex + 25);
+    const stage6Text = stage6Slice.join("\n");
+
+    expect(stage6Text).toMatch(/stages? 1/iu);
+    expect(stage6Text).toMatch(/stages? 5|stages? 1.5|prior/iu);
+    expect(stage6Text).toMatch(/validat|verify|populated/iu);
+  });
+});

--- a/packages/design-pipeline/src/skill-tests/state-documentation-shed.test.ts
+++ b/packages/design-pipeline/src/skill-tests/state-documentation-shed.test.ts
@@ -1,0 +1,64 @@
+import includes from "lodash/includes.js";
+import some from "lodash/some.js";
+import split from "lodash/split.js";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const SKILL_PATH = path.join(
+  __dirname,
+  "..",
+  "..",
+  "..",
+  "..",
+  ".claude",
+  "skills",
+  "design-pipeline",
+  "SKILL.md",
+);
+
+const content = readFileSync(SKILL_PATH, "utf8");
+const lines = split(content, "\n");
+
+describe("design-pipeline SKILL.md — state documentation shed", () => {
+  it("does NOT contain the heading '## Pipeline Change Tracking'", () => {
+    const hasHeading = some(lines, (line) => {
+      return includes(line, "## Pipeline Change Tracking");
+    });
+
+    expect(hasHeading).toBe(false);
+  });
+
+  it("does NOT contain the heading '## Accumulated Context'", () => {
+    const hasHeading = some(lines, (line) => {
+      return includes(line, "## Accumulated Context");
+    });
+
+    expect(hasHeading).toBe(false);
+  });
+
+  it("does NOT contain the heading '### Session File Format'", () => {
+    const hasHeading = some(lines, (line) => {
+      return includes(line, "### Session File Format");
+    });
+
+    expect(hasHeading).toBe(false);
+  });
+
+  it("does NOT contain 'docs/design-pipeline-sessions/' anywhere", () => {
+    expect(content).not.toContain("docs/design-pipeline-sessions/");
+  });
+
+  it("does NOT contain 'Pipeline Session Index' in the Output Locations table", () => {
+    expect(content).not.toContain("Pipeline Session Index");
+  });
+
+  it("still contains all six stage execution sections", () => {
+    expect(content).toContain("### Stage 1");
+    expect(content).toContain("### Stage 2");
+    expect(content).toContain("### Stage 3");
+    expect(content).toContain("### Stage 4");
+    expect(content).toContain("### Stage 5");
+    expect(content).toContain("### Stage 6");
+  });
+});

--- a/packages/design-pipeline/src/skill-tests/state-file-lifecycle.test.ts
+++ b/packages/design-pipeline/src/skill-tests/state-file-lifecycle.test.ts
@@ -1,0 +1,124 @@
+import findIndex from "lodash/findIndex.js";
+import includes from "lodash/includes.js";
+import some from "lodash/some.js";
+import split from "lodash/split.js";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const SKILL_PATH = path.join(
+  __dirname,
+  "..",
+  "..",
+  "..",
+  "..",
+  ".claude",
+  "skills",
+  "design-pipeline",
+  "SKILL.md",
+);
+
+const content = readFileSync(SKILL_PATH, "utf8");
+const lines = split(content, "\n");
+
+const STATE_FILE_PATH = "docs/pipeline-state.md";
+
+describe("design-pipeline SKILL.md — state file lifecycle", () => {
+  it("contains a section heading about the pipeline state file", () => {
+    const hasHeading = some(lines, (line) => {
+      return includes(line, "State File") || includes(line, "Pipeline State");
+    });
+
+    expect(hasHeading).toBe(true);
+  });
+
+  it("references the state file path docs/pipeline-state.md", () => {
+    expect(content).toContain(STATE_FILE_PATH);
+  });
+
+  it("contains 'fail-fast' in the context of clear failure", () => {
+    expect(content).toContain("fail-fast");
+  });
+
+  it("contains section ownership rule", () => {
+    const hasSectionOwnership =
+      includes(content, "section ownership") ||
+      includes(content, "section-scoped ownership") ||
+      includes(content, "Section-Scoped Ownership");
+
+    expect(hasSectionOwnership).toBe(true);
+  });
+
+  it("contains schema validation language", () => {
+    const hasSchemaValidation =
+      includes(content, "schema validation") ||
+      includes(content, "Schema Validation") ||
+      includes(content, "validates");
+
+    expect(hasSchemaValidation).toBe(true);
+  });
+
+  it("contains 'terminal' in the context of commits", () => {
+    const hasTerminalCommit = some(lines, (line) => {
+      return includes(line, "terminal") && includes(line, "commit");
+    });
+
+    expect(hasTerminalCommit).toBe(true);
+  });
+
+  it("contains 'uncommitted' in the context of warning before clearing", () => {
+    const hasUncommittedWarning = some(lines, (line) => {
+      return includes(line, "uncommitted");
+    });
+
+    expect(hasUncommittedWarning).toBe(true);
+  });
+
+  it("includes docs/pipeline-state.md in the Output Locations table", () => {
+    const outputLocationsIndex = findIndex(lines, (line) => {
+      return includes(line, "## Output Locations");
+    });
+
+    expect(outputLocationsIndex).toBeGreaterThan(-1);
+
+    const tableSlice = lines.slice(
+      outputLocationsIndex,
+      outputLocationsIndex + 20,
+    );
+    const hasStateFileRow = some(tableSlice, (line) => {
+      return includes(line, STATE_FILE_PATH);
+    });
+
+    expect(hasStateFileRow).toBe(true);
+  });
+
+  it("references the state file path in the COMPLETE presentation block", () => {
+    const completeIndex = findIndex(lines, (line) => {
+      return includes(line, "Design Pipeline Complete");
+    });
+
+    expect(completeIndex).toBeGreaterThan(-1);
+
+    const completeSlice = lines.slice(completeIndex, completeIndex + 25);
+    const hasStateFile = some(completeSlice, (line) => {
+      return includes(line, STATE_FILE_PATH);
+    });
+
+    expect(hasStateFile).toBe(true);
+  });
+
+  it("references the state file path in the HALTED presentation block", () => {
+    const haltedIndex = findIndex(lines, (line) => {
+      return includes(line, "Design Pipeline Halted");
+    });
+
+    expect(haltedIndex).toBeGreaterThan(-1);
+
+    const haltedSlice = lines.slice(haltedIndex, haltedIndex + 15);
+    const hasStateFile = some(haltedSlice, (line) => {
+      return includes(line, STATE_FILE_PATH);
+    });
+
+    expect(hasStateFile).toBe(true);
+  });
+});

--- a/packages/design-pipeline/src/skill-tests/tla-writer-state-write.test.ts
+++ b/packages/design-pipeline/src/skill-tests/tla-writer-state-write.test.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const AGENT_PATH = path.join(
+  import.meta.dirname,
+  "..",
+  "..",
+  "..",
+  "..",
+  ".claude",
+  "skills",
+  "tla-writer",
+  "AGENT.md",
+);
+
+const content = readFileSync(AGENT_PATH, "utf8");
+
+const PIPELINE_STATE_FILE = "pipeline-state.md";
+const STAGE_3 = "Stage 3";
+
+describe("tla-writer AGENT.md — pipeline state file instructions", () => {
+  it("references the pipeline state file", () => {
+    expect(content).toContain(PIPELINE_STATE_FILE);
+  });
+
+  it("contains instructions about writing a Stage 3 StageResult section", () => {
+    expect(content).toContain(STAGE_3);
+    expect(content).toMatch(/stage 3.*stageresult/iu);
+  });
+
+  it("contains instructions about validating prior stages before writing", () => {
+    expect(content).toMatch(/stage 1/iu);
+    expect(content).toMatch(/stage 2/iu);
+    expect(content).toMatch(/validat|check|verify|populated|present/iu);
+  });
+
+  it("describes the conditional detection for pipeline runs via ACCUMULATING status", () => {
+    expect(content).toContain("ACCUMULATING");
+  });
+
+  it("instructs writing only to the Stage 3 section (section-scoped ownership)", () => {
+    expect(content).toMatch(/only.*stage 3|stage 3.*only|section.scoped/iu);
+  });
+
+  it("includes Status, Artifact, and Timestamp fields in the Stage 3 output", () => {
+    const pipelineSection = content.slice(content.indexOf(PIPELINE_STATE_FILE));
+    expect(pipelineSection).toMatch(/status/iu);
+    expect(pipelineSection).toMatch(/artifact/iu);
+    expect(pipelineSection).toMatch(/timestamp/iu);
+  });
+
+  it("mentions COMPLETE and UNVERIFIED as possible status values", () => {
+    expect(content).toContain("COMPLETE");
+    expect(content).toContain("UNVERIFIED");
+  });
+});

--- a/packages/leetcode/package.json
+++ b/packages/leetcode/package.json
@@ -12,6 +12,7 @@
     "@vitest/coverage-v8": "^4.1.2",
     "eslint": "^10.1.0",
     "typescript": "^6.0.2",
+    "vite": "^8.0.3",
     "vitest": "^4.1.2"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -712,6 +712,9 @@ importers:
       typescript:
         specifier: ^6.0.2
         version: 6.0.2
+      vite:
+        specifier: ^8.0.3
+        version: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.2)(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.2
         version: 4.1.2(@types/node@25.5.0)(@vitest/ui@4.1.2)(happy-dom@20.8.9)(jsdom@29.0.1(@noble/hashes@2.0.1))(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.2)(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -13328,7 +13331,7 @@ snapshots:
 
   '@npmcli/fs@5.0.0':
     dependencies:
-      semver: 7.7.3
+      semver: 7.7.4
 
   '@npmcli/git@7.0.2':
     dependencies:
@@ -13338,7 +13341,7 @@ snapshots:
       lru-cache: 11.2.7
       npm-pick-manifest: 11.0.3
       proc-log: 6.1.0
-      semver: 7.7.3
+      semver: 7.7.4
       which: 6.0.1
 
   '@npmcli/installed-package-contents@4.0.0':
@@ -13355,7 +13358,7 @@ snapshots:
       hosted-git-info: 9.0.2
       json-parse-even-better-errors: 5.0.0
       proc-log: 6.1.0
-      semver: 7.7.3
+      semver: 7.7.4
       spdx-expression-parse: 4.0.0
 
   '@npmcli/promise-spawn@9.0.1':
@@ -18886,7 +18889,7 @@ snapshots:
       make-fetch-happen: 15.0.5
       nopt: 9.0.0
       proc-log: 6.1.0
-      semver: 7.7.3
+      semver: 7.7.4
       tar: 7.5.13
       tinyglobby: 0.2.15
       which: 6.0.1
@@ -18925,7 +18928,7 @@ snapshots:
 
   npm-install-checks@8.0.0:
     dependencies:
-      semver: 7.7.3
+      semver: 7.7.4
 
   npm-normalize-package-bin@5.0.0: {}
 
@@ -18933,7 +18936,7 @@ snapshots:
     dependencies:
       hosted-git-info: 9.0.2
       proc-log: 6.1.0
-      semver: 7.7.3
+      semver: 7.7.4
       validate-npm-package-name: 7.0.2
 
   npm-packlist@10.0.4:
@@ -18946,7 +18949,7 @@ snapshots:
       npm-install-checks: 8.0.0
       npm-normalize-package-bin: 5.0.0
       npm-package-arg: 13.0.2
-      semver: 7.7.3
+      semver: 7.7.4
 
   npm-registry-fetch@19.1.1:
     dependencies:


### PR DESCRIPTION
## Summary

- Introduces `docs/pipeline-state.md` as a singleton shared state file that persists cross-agent variables (expert selections, writer assignments, stage results) across all subagent calls in the design pipeline
- Cleans stale expert-selection references from design-pipeline SKILL.md (PR #40 follow-up: questioner no longer selects experts)
- Sheds state documentation from SKILL.md — state file becomes the single source of truth; SKILL.md focuses on behavioral instructions only
- Adds section-scoped write instructions to all 5 participating agents (questioner, debate-moderator, tla-writer, implementation-writer, design-pipeline)
- TLA+ specification with 10 safety invariants + 2 liveness properties, verified by TLC model checker
- 9 new test files (406 total tests, 100% coverage)

## Design Decisions

| Property | Decision |
|---|---|
| Format | Markdown |
| Location | `docs/pipeline-state.md` |
| Lifecycle | Cleared at run start; left in place after completion |
| Write model | Distributed — each agent writes its own section |
| Conflict prevention | Section-scoped ownership; cross-section writes are bugs |
| Commits | Terminal-state-only (COMPLETE or HALTED) |
| Archive | Git history (no separate archive step) |
| Session index | Eliminated — state file replaces `docs/design-pipeline-sessions/` |

## Test plan

- [x] 406 tests passing (45 test files)
- [x] 100% code coverage
- [x] ESLint clean
- [x] TLA+ spec verified by TLC (10 invariants, 2 liveness properties)
- [x] Integration test validates cross-file coherence across all 5 agent files
- [x] No stale "Expert Council" or session index references remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)