### PR TITLE
🧪 Add tests for useMap hook

### DIFF
--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -13,12 +13,17 @@
   "devDependencies": {
     "@ethang/eslint-config": "^25.19.5",
     "@ethang/project-builder": "^3.0.2",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/lodash": "^4.17.24",
     "@types/node": "^25.9.2",
     "@types/react": "^19.2.17",
+    "@vitest/coverage-v8": "^4.1.8",
     "browserslist-config-baseline": "^0.5.0",
+    "jsdom": "^29.1.1",
     "typescript": "^6.0.3",
-    "vite": "^8.0.16"
+    "vite": "^8.0.16",
+    "vitest": "^4.1.8"
   },
   "engines": {
     "node": ">=24"
@@ -28,7 +33,8 @@
   "repository": "https://github.com/eglove/hooks",
   "scripts": {
     "build": "bun build.ts",
-    "lint": "eslint src/ --fix && pnpm tsc --noEmit"
+    "lint": "eslint src/ --fix && pnpm tsc --noEmit",
+    "test": "vitest run --coverage"
   },
   "type": "module",
   "version": "2.3.1"

--- a/packages/hooks/tests/use-map.test.ts
+++ b/packages/hooks/tests/use-map.test.ts
@@ -1,0 +1,98 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { useMap } from "../src/use-map.js";
+
+describe("useMap", () => {
+  it("should initialize with an empty map if no values are provided", () => {
+    const { result } = renderHook(() => {
+      return useMap();
+    });
+
+    expect(result.current.size).toBe(0);
+  });
+
+  it("should initialize with the provided values", () => {
+    const { result } = renderHook(() => {
+      return useMap([
+        ["key1", "value1"],
+        ["key2", "value2"],
+      ]);
+    });
+
+    expect(result.current.size).toBe(2);
+    expect(result.current.get("key1")).toBe("value1");
+    expect(result.current.get("key2")).toBe("value2");
+  });
+
+  it("should add a new key-value pair when set is called", () => {
+    const { result } = renderHook(() => {
+      return useMap<string, string>();
+    });
+
+    act(() => {
+      result.current.set("key1", "value1");
+    });
+
+    expect(result.current.size).toBe(1);
+    expect(result.current.get("key1")).toBe("value1");
+  });
+
+  it("should update an existing key when set is called", () => {
+    const { result } = renderHook(() => {
+      return useMap([["key1", "value1"]]);
+    });
+
+    act(() => {
+      result.current.set("key1", "new_value");
+    });
+
+    expect(result.current.size).toBe(1);
+    expect(result.current.get("key1")).toBe("new_value");
+  });
+
+  it("should remove a key-value pair when delete is called", () => {
+    const { result } = renderHook(() => {
+      return useMap([["key1", "value1"]]);
+    });
+
+    let deleteResult: boolean | undefined;
+
+    act(() => {
+      deleteResult = result.current.delete("key1");
+    });
+
+    expect(result.current.size).toBe(0);
+    expect(result.current.has("key1")).toBe(false);
+    expect(deleteResult).toBe(true);
+  });
+
+  it("should return false when deleting a non-existent key", () => {
+    const { result } = renderHook(() => {
+      return useMap();
+    });
+
+    let deleteResult: boolean | undefined;
+
+    act(() => {
+      deleteResult = result.current.delete("non_existent_key");
+    });
+
+    expect(deleteResult).toBe(false);
+  });
+
+  it("should remove all key-value pairs when clear is called", () => {
+    const { result } = renderHook(() => {
+      return useMap([
+        ["key1", "value1"],
+        ["key2", "value2"],
+      ]);
+    });
+
+    act(() => {
+      result.current.clear();
+    });
+
+    expect(result.current.size).toBe(0);
+  });
+});

--- a/packages/hooks/tsconfig.json
+++ b/packages/hooks/tsconfig.json
@@ -3,5 +3,6 @@
   "compilerOptions": {
     "moduleResolution": "bundler",
     "types": ["node", "vite/client"]
-  }
+  },
+  "include": ["src", "tests"]
 }

--- a/packages/hooks/vitest.config.ts
+++ b/packages/hooks/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      include: ["src/use-map.ts"],
+      provider: "v8",
+      reporter: ["text", "json", "html", "lcov"],
+      thresholds: {
+        autoUpdate: true,
+        branches: 100,
+        functions: 100,
+        lines: 100,
+        statements: 100,
+      },
+    },
+    environment: "jsdom",
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -891,6 +891,12 @@ importers:
       '@ethang/project-builder':
         specifier: ^3.0.2
         version: 3.0.2(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0)
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/lodash':
         specifier: ^4.17.24
         version: 4.17.24
@@ -900,15 +906,24 @@ importers:
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
+      '@vitest/coverage-v8':
+        specifier: ^4.1.8
+        version: 4.1.8(vitest@4.1.8)
       browserslist-config-baseline:
         specifier: ^0.5.0
         version: 0.5.0
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1(@noble/hashes@2.2.0)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
       vite:
         specifier: ^8.0.16
         version: 8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(happy-dom@20.10.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/leetcode:
     dependencies:


### PR DESCRIPTION
🎯 **What:** The `useMap` hook was completely untested. This PR introduces a dedicated test suite using `vitest` and `@testing-library/react`.
📊 **Coverage:** Tests cover initial state with and without values, as well as `set` (add and update), `delete` (existing and non-existent), and `clear` methods.
✨ **Result:** Reached 100% test coverage for the `useMap` hook, ensuring it's more reliable.

---
*PR created automatically by Jules for task [11273711790760300843](https://jules.google.com/task/11273711790760300843) started by @eglove*