### PR TITLE
refactor(agents-build): remove hooks system and prefer-tool-hooks rule

### DIFF
--- a/.github/skills/lint/resources/knowledge-base.md
+++ b/.github/skills/lint/resources/knowledge-base.md
@@ -29,7 +29,7 @@ The following entries are accumulated solutions to difficult lint rules encounte
 ### TypeScript: TS4104 (readonly type mismatch)
 
 * **Rule:** `readonly` arrays cannot be assigned to mutable array types.
-* **Problem:* `GLOBAL_COMMANDS` is declared `as const` (producing `readonly [CommandDefinition, CommandDefinition]`), but `CompilerConfig.commands` was typed as `CommandDefinition[]` (mutable).
+* **Problem:** `GLOBAL_COMMANDS` is declared `as const` (producing `readonly [CommandDefinition, CommandDefinition]`), but `CompilerConfig.commands` was typed as `CommandDefinition[]` (mutable).
 * **Solution:** Change the `commands` property type in `CompilerConfig` from `CommandDefinition[]` to `readonly CommandDefinition[]`, since the compiler never mutates the input arrays.
 
 ### no-continue

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,11 +41,22 @@ integrity, and drift checks.
 
 ---
 
+## Skills Discovery
+
+Skills are available in two locations:
+
+* **`.github/skills/`** — Custom skills specific to this repository
+* **`.agents/skills/`** — Generated skills from the compiler
+
+When resolving skill references, check both locations. The `.agents/skills/` directory contains built-in and generated skills (402 items), while `.github/skills/` contains repository-specific custom skills (7 items).
+
+---
+
 ## CRITICAL: Tool Usage
 
 AI agents must follow this tool priority order:
 
-1. **webstorm** — use for: file writes/creates/renames, refactoring, builds, database/SQL queries
+1. **WebStorm MCP** — use for: file reads/writes/creates/renames, refactoring, builds, database/SQL queries, code search, symbol navigation, rename refactoring
 2. **PowerShell + Specialized CLIs** (fallback) — use `rg`, `jq`, `es` (Everything Search), `gh`
 
 ---

--- a/packages/agents-build/src/compiler-core.test.ts
+++ b/packages/agents-build/src/compiler-core.test.ts
@@ -391,25 +391,6 @@ describe("hooks generation", () => {
     rmSync(temporaryDirectory, { force: true, recursive: true });
   });
 
-  it("does not generate hooks config when hooksPath is provided (hooks generation removed)", () => {
-    const rulesDirectory = path.join(temporaryDirectory, rulesDirectoryName);
-    const skillsDirectory = path.join(temporaryDirectory, "skills");
-    const hooksPath = path.join(temporaryDirectory, "hooks.json");
-
-    const config: CompilerConfig = {
-      hooksPath,
-      rootDir: temporaryDirectory,
-      rules: [],
-      rulesDir: rulesDirectory,
-      skills: [],
-      skillsDir: skillsDirectory
-    };
-
-    compile(config);
-
-    expect(existsSync(hooksPath)).toBe(false);
-  });
-
   it("skips hooks generation when hooksPath is not provided", () => {
     const rulesDirectory = path.join(temporaryDirectory, rulesDirectoryName);
     const skillsDirectory = path.join(temporaryDirectory, "skills");

--- a/packages/agents-build/src/compiler-core.ts
+++ b/packages/agents-build/src/compiler-core.ts
@@ -55,22 +55,6 @@ export const MCP_SERVERS: McpConfig = {
   }
 };
 
-export const HOOKS = {
-  hooks: {
-    sessionStart: [
-      {
-        prompt: "/swebok",
-        type: "prompt"
-      },
-      {
-        prompt: "/ddd",
-        type: "prompt"
-      }
-    ]
-  },
-  version: 1
-};
-
 export class CompileError extends Error {
   public failures: string[];
 
@@ -107,8 +91,6 @@ const processMcpConfig = (
 
   write(config.mcpPublicPath, JSON.stringify(MCP_SERVERS, null, 2));
 };
-
-// Removed hooks generation logic as requested
 
 const processRules = (
   config: CompilerConfig,

--- a/packages/agents-build/src/content/skills/global.ts
+++ b/packages/agents-build/src/content/skills/global.ts
@@ -7,11 +7,11 @@ import { ripgrep } from "./ripgrep.ts";
 import { swebok } from "./swebok/swebok.ts";
 
 export const GLOBAL_SKILLS = [
+  lint,
   swebok,
   ddd,
-  ripgrep,
-  jq,
   everythingSearch,
   githubCli,
-  lint
+  ripgrep,
+  jq
 ];

--- a/packages/agents-build/src/content/skills/lint.ts
+++ b/packages/agents-build/src/content/skills/lint.ts
@@ -108,8 +108,38 @@ The following entries are accumulated solutions to difficult lint rules encounte
 ### TypeScript: TS4104 (readonly type mismatch)
 
 * **Rule:** \`readonly\` arrays cannot be assigned to mutable array types.
-* **Problem:* \`GLOBAL_COMMANDS\` is declared \`as const\` (producing \`readonly [CommandDefinition, CommandDefinition]\`), but \`CompilerConfig.commands\` was typed as \`CommandDefinition[]\` (mutable).
+* **Problem:** \`GLOBAL_COMMANDS\` is declared \`as const\` (producing \`readonly [CommandDefinition, CommandDefinition]\`), but \`CompilerConfig.commands\` was typed as \`CommandDefinition[]\` (mutable).
 * **Solution:** Change the \`commands\` property type in \`CompilerConfig\` from \`CommandDefinition[]\` to \`readonly CommandDefinition[]\`, since the compiler never mutates the input arrays.
+
+### no-continue
+
+* **Rule:** The \`continue\` statement is forbidden.
+* **Problem:** \`for (const x of list) { if (!condition) { continue; } ... }\` — early-skip pattern using \`continue\`.
+* **Solution:** Invert the condition to wrap the loop body instead: \`for (const x of list) { if (condition) { ... } }\`. This avoids \`continue\` entirely while preserving the same control flow.
+
+### no-plusplus
+
+* **Rule:** Unary \`++\` / \`--\` operators are forbidden.
+* **Problem:** \`courseIndex++\` used to increment a counter in a loop body.
+* **Solution:** Use \`+= 1\` instead: \`courseIndex += 1\`.
+
+### unicorn/prefer-iterator-to-array
+
+* **Rule:** Prefer \`Iterator#toArray()\` over spreading an iterator into an array.
+* **Problem:** \`[...coursesByLp.keys()]\` creates a temporary spread array from a \`Map\` iterator.
+* **Solution:** Replace with \`coursesByLp.keys().toArray()\`.
+
+### sonar/nested-control-flow
+
+* **Rule:** Control flow nesting depth exceeds the allowed limit (typically 3 levels).
+* **Problem:** A loop body contains \`if\` statements that themselves contain loops and further \`if\`s, reaching 4+ levels of braces.
+* **Solution:** Flatten nested structures using \`flatMap\` (or lodash \`flatMap\`) to merge an inner loop's results into the outer array, then iterate the flattened result with a single \`for...of\`. This keeps each loop body at ≤3 nesting levels.
+
+### @typescript-eslint/no-shadow
+
+* **Rule:** Variables declared in outer scopes must not be redeclared in inner scopes.
+* **Problem:** Module-level constants (\`CREATED_AT\`, \`COURSE_1\`, \`LP_1\`, etc.) were redeclared with identical values inside a nested \`describe\` block's callback, causing shadowing.
+* **Solution:** Remove the inner redeclarations and reference the module-level constants directly. Ensure mock data uses the same values as the module-level constants for assertions to match.
 `,
       filename: "knowledge-base.md"
     }


### PR DESCRIPTION
## Summary

Removes the tool hooks/prefer-tool-hooks system from \packages/agents-build/\ and all compiled artifacts.

### Changes

- **compiler-core.ts**: Removed \HOOKS\ export, \processHooks()\ call, and \preToolUseHooks\ import
- **compiler-core.test.ts**: Removed hooks generation test
- **content/skills/global.ts**: Reordered \GLOBAL_SKILLS\ (lint first)
- **content/skills/lint.ts**: Added 5 missing knowledge-base entries and fixed a typo
- **Compiled artifacts**: \.github/hooks/skills.json\, \.github/instructions/prefer-tool-hooks.md\ no longer generated
- **AGENTS.md**: Updated tool usage documentation